### PR TITLE
feat: Add build step for LLM callbacks handlers

### DIFF
--- a/plugins/enthusiast-common/enthusiast_common/builder/base.py
+++ b/plugins/enthusiast-common/enthusiast_common/builder/base.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Generic, TypeVar, Optional
+from typing import Generic, Optional, TypeVar
 
 from langchain_core.callbacks import BaseCallbackHandler
 from langchain_core.language_models import BaseLanguageModel
@@ -48,7 +48,7 @@ class BaseAgentBuilder(ABC, Generic[ConfigT]):
         tools: list[BaseTool],
         llm: BaseLanguageModel,
         prompt: PromptTemplate | ChatMessagePromptTemplate,
-        callback_handler: BaseCallbackHandler
+        callback_handler: BaseCallbackHandler,
     ) -> BaseAgent:
         pass
 
@@ -98,6 +98,10 @@ class BaseAgentBuilder(ABC, Generic[ConfigT]):
 
     @abstractmethod
     def _build_agent_callback_handler(self) -> Optional[BaseCallbackHandler]:
+        pass
+
+    @abstractmethod
+    def _build_llm_callback_handlers(self) -> Optional[BaseCallbackHandler]:
         pass
 
     @abstractmethod

--- a/plugins/enthusiast-common/enthusiast_common/config/__init__.py
+++ b/plugins/enthusiast-common/enthusiast_common/config/__init__.py
@@ -3,6 +3,7 @@ from .base import (
     AgentConfig,
     AgentConfigWithDefaults,
     AgentToolConfig,
+    CallbackHandlerConfig,
     EmbeddingsRegistryConfig,
     LLMConfig,
     LLMRegistryConfig,
@@ -28,4 +29,5 @@ __all__ = [
     "LLMRegistryConfig",
     "RetrieverConfig",
     "AgentCallbackHandlerConfig",
+    "CallbackHandlerConfig",
 ]

--- a/plugins/enthusiast-common/enthusiast_common/config/base.py
+++ b/plugins/enthusiast-common/enthusiast_common/config/base.py
@@ -52,9 +52,14 @@ class RegistryConfig(ArbitraryTypeBaseModel):
     model: ModelsRegistryConfig
 
 
+class CallbackHandlerConfig(ArbitraryTypeBaseModel):
+    handler_class: Type[BaseCallbackHandler]
+    args: dict[str, Any] = Field(default_factory=dict)
+
+
 class LLMConfig(ArbitraryTypeBaseModel):
     llm_class: Type[BaseLLM] = BaseLLM
-    callbacks: Optional[list[BaseCallbackHandler]] = None
+    callbacks: Optional[list[CallbackHandlerConfig]] = None
     streaming: bool = False
 
 

--- a/server/agent/callbacks.py
+++ b/server/agent/callbacks.py
@@ -45,8 +45,8 @@ class ConversationWebSocketCallbackHandler(BaseWebSocketHandler):
 
 
 class ReactAgentWebsocketCallbackHandler(ConversationWebSocketCallbackHandler):
-    def __init__(self, conversation):
-        super().__init__(conversation)
+    def __init__(self, conversation_id: int):
+        super().__init__(conversation_id)
         self.first_final_answer_chunk = False
         self.second_final_answer_chunk = False
         self.third_final_answer_chunk = False

--- a/server/agent/core/agents/default_config.py
+++ b/server/agent/core/agents/default_config.py
@@ -3,6 +3,7 @@ from typing import Type
 from enthusiast_common.config import (
     AgentConfig,
     AgentConfigWithDefaults,
+    CallbackHandlerConfig,
     EmbeddingsRegistryConfig,
     LLMConfig,
     LLMRegistryConfig,
@@ -69,7 +70,11 @@ def get_default_config(conversation_id: int, streaming: bool) -> DefaultAgentCon
             model=ModelsRegistryConfig(registry_class=BaseDjangoSettingsDBModelRegistry),
         ),
         llm=LLMConfig(
-            callbacks=[ConversationWebSocketCallbackHandler(conversation_id=conversation_id)],
+            callbacks=[
+                CallbackHandlerConfig(
+                    handler_class=ConversationWebSocketCallbackHandler, args={"conversation_id": conversation_id}
+                ),
+            ],
             streaming=streaming,
         ),
     )

--- a/server/agent/core/agents/product_search_react_agent/config.py
+++ b/server/agent/core/agents/product_search_react_agent/config.py
@@ -1,6 +1,7 @@
 from enthusiast_common.config import (
     AgentCallbackHandlerConfig,
     AgentConfigWithDefaults,
+    CallbackHandlerConfig,
     LLMConfig,
     LLMToolConfig,
     RetrieverConfig,
@@ -32,7 +33,12 @@ def get_config(conversation_id: int, streaming: bool) -> AgentConfigWithDefaults
             LLMToolConfig(tool_class=ProductVerificationTool),
         ],
         llm=LLMConfig(
-            callbacks=[ReactAgentWebsocketCallbackHandler(conversation_id), StdOutCallbackHandler()],
+            callbacks=[
+                CallbackHandlerConfig(
+                    handler_class=ReactAgentWebsocketCallbackHandler, args={"conversation_id": conversation_id}
+                ),
+                CallbackHandlerConfig(handler_class=StdOutCallbackHandler),
+            ],
             streaming=streaming,
         ),
         retrievers=RetrieversConfig(

--- a/server/agent/core/agents/tool_calling_agent/config.py
+++ b/server/agent/core/agents/tool_calling_agent/config.py
@@ -1,7 +1,6 @@
-from enthusiast_common.config import AgentConfigWithDefaults, LLMConfig, LLMToolConfig
+from enthusiast_common.config import AgentConfigWithDefaults, LLMToolConfig
 from langchain_core.prompts import ChatPromptTemplate
 
-from agent.callbacks import ConversationWebSocketCallbackHandler
 from agent.core.agents import ToolCallingAgent
 from agent.tools import CreateAnswerTool
 
@@ -26,5 +25,4 @@ def get_config(conversation_id: int, streaming: bool) -> AgentConfigWithDefaults
                 tool_class=CreateAnswerTool,
             )
         ],
-        llm=LLMConfig(callbacks=[ConversationWebSocketCallbackHandler(conversation_id)], streaming=streaming),
     )


### PR DESCRIPTION
We are adding this build step to avoid adding callback handlers instances to config, we'll pass class instead. And build it inside builder