### PR TITLE
chore: Move building memory instances to injector build step

### DIFF
--- a/plugins/enthusiast-common/enthusiast_common/builder/base.py
+++ b/plugins/enthusiast-common/enthusiast_common/builder/base.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Generic, TypeVar, Optional
+from typing import Generic, Optional, TypeVar
 
 from langchain_core.callbacks import BaseCallbackHandler
 from langchain_core.language_models import BaseLanguageModel
@@ -25,8 +25,6 @@ class BaseAgentBuilder(ABC, Generic[ConfigT]):
         self._embeddings_registry = None
         self._data_set_id = None
         self._injector = None
-        self._chat_summary_memory = None
-        self._chat_limited_memory = None
         self._config = config
 
     def build(self) -> BaseAgent:
@@ -35,8 +33,6 @@ class BaseAgentBuilder(ABC, Generic[ConfigT]):
         self._data_set_id = self._repositories.conversation.get_data_set_id(self._config.conversation_id)
         self._llm = self._build_llm(self._config.llm)
         self._embeddings_registry = self._build_embeddings_registry()
-        self._chat_summary_memory = self._build_chat_summary_memory()
-        self._chat_limited_memory = self._build_chat_limited_memory()
         self._injector = self._build_injector()
         tools = self._build_tools(default_llm=self._llm, injector=self._injector)
         agent_callback_handler = self._build_agent_callback_handler()
@@ -48,7 +44,7 @@ class BaseAgentBuilder(ABC, Generic[ConfigT]):
         tools: list[BaseTool],
         llm: BaseLanguageModel,
         prompt: PromptTemplate | ChatMessagePromptTemplate,
-        callback_handler: BaseCallbackHandler
+        callback_handler: BaseCallbackHandler,
     ) -> BaseAgent:
         pass
 

--- a/server/agent/core/builder.py
+++ b/server/agent/core/builder.py
@@ -123,12 +123,14 @@ class AgentBuilder(BaseAgentBuilder[AgentConfig]):
     def _build_injector(self) -> BaseInjector:
         document_retriever = self._build_document_retriever()
         product_retriever = self._build_product_retriever()
+        chat_summary_memory = self._build_chat_summary_memory()
+        chat_limited_memory = self._build_chat_limited_memory()
         return self._config.injector(
             product_retriever=product_retriever,
             document_retriever=document_retriever,
             repositories=self._repositories,
-            chat_summary_memory=self._chat_summary_memory,
-            chat_limited_memory=self._chat_limited_memory,
+            chat_summary_memory=chat_summary_memory,
+            chat_limited_memory=chat_limited_memory,
         )
 
     def _build_agent_callback_handler(self) -> Optional[BaseCallbackHandler]:


### PR DESCRIPTION
I moved building memory steps to `_build_injector`, because in case someone want to add custom memory, there is no need to override whole enthusiast_common Builder's `build` method only the abstract one(`_build_injector`).
