### PR TITLE
chore: Make sure that all the API endpoints generate swagger docs

### DIFF
--- a/server/account/views/accounts.py
+++ b/server/account/views/accounts.py
@@ -1,13 +1,17 @@
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
-
+from drf_yasg.utils import swagger_auto_schema
 from account.serializers import AccountSerializer
 
 
 class AccountView(APIView):
     permission_classes = [IsAuthenticated]
 
+    @swagger_auto_schema(
+        operation_description="Get the current user's account",
+        responses={200: AccountSerializer}
+    )
     def get(self, request):
         serializer = AccountSerializer(request.user)
         return Response(serializer.data, status=200)

--- a/server/account/views/login.py
+++ b/server/account/views/login.py
@@ -18,7 +18,15 @@ class LoginView(APIView):
         ),
         responses={
             200: openapi.Response(
-                description="Token retrieved successfully", examples={"application/json": {"token": "string"}}
+                description="Token retrieved successfully",schema=openapi.Schema(
+                    type=openapi.TYPE_OBJECT,
+                    properties={
+                        "token": openapi.Schema(
+                            type=openapi.TYPE_STRING,
+                            description="Authentication token"
+                        )
+                    },
+                ),
             ),
             403: "Forbidden",
         },

--- a/server/account/views/service_accounts.py
+++ b/server/account/views/service_accounts.py
@@ -38,6 +38,7 @@ class ResetTokenView(APIView):
         manual_parameters=[
             openapi.Parameter("id", openapi.IN_PATH, description="ID of the service account", type=openapi.TYPE_INTEGER)
         ],
+        responses={200: openapi.Response(description="Token", schema=openapi.Schema(type=openapi.TYPE_STRING))},
     )
     def post(self, request, id):
         service_account = User.objects.get(id=id, is_service_account=True)
@@ -50,6 +51,12 @@ class ServiceAccountListView(ListAPIView):
     permission_classes = [IsAdminUser]
     serializer_class = ServiceAccountSerializer
     queryset = User.objects.filter(is_service_account=True).order_by("-date_joined")
+
+    @swagger_auto_schema(
+        operation_description="Get list of service accounts",
+    )
+    def get(self, request, *args, **kwargs):
+        return super().get(request, *args, **kwargs)
 
     @swagger_auto_schema(
         operation_description="Create a new service account", request_body=CreateUpdateServiceAccountSerializer

--- a/server/agent/views.py
+++ b/server/agent/views.py
@@ -46,6 +46,7 @@ class GetTaskStatus(APIView):
         manual_parameters=[
             openapi.Parameter("task_id", openapi.IN_PATH, description="ID of the task", type=openapi.TYPE_STRING)
         ],
+        responses={200: openapi.Response(description="Task status", schema=openapi.Schema(type=openapi.TYPE_OBJECT, properties={"state": openapi.Schema(type=openapi.TYPE_STRING)}))},
     )
     def get(self, request, task_id):
         task_result = AsyncResult(task_id)
@@ -67,6 +68,7 @@ class ConversationView(APIView):
                 "conversation_id", openapi.IN_PATH, description="ID of the conversation", type=openapi.TYPE_INTEGER
             )
         ],
+        responses={200: ConversationContentSerializer()},
     )
     def get(self, request, conversation_id):
         conversation = (
@@ -130,6 +132,9 @@ class ConversationListView(ListAPIView):
             )
         ],
     )
+    def get(self, request, *args, **kwargs):
+        return super().get(request, *args, **kwargs)
+
     def get_queryset(self):
         user = self.request.user
         data_set_id = self.request.query_params.get("data_set_id")
@@ -230,7 +235,16 @@ class AgentView(APIView):
     """View to get/create agents"""
 
     @swagger_auto_schema(
-        operation_description="Get list of all dataset's agents",
+        operation_description="List all agents for a dataset",
+        manual_parameters=[
+            openapi.Parameter(
+                "dataset",
+                openapi.IN_QUERY,
+                description="ID of the dataset",
+                type=openapi.TYPE_INTEGER,
+                required=True,
+            )
+        ],
         responses={200: AgentListSerializer(many=True)},
     )
     def get(self, request):

--- a/server/catalog/views.py
+++ b/server/catalog/views.py
@@ -38,6 +38,11 @@ from .serializers import (
 class SyncAllSourcesView(GenericAPIView):
     permission_classes = [IsAdminUser]
 
+    @swagger_auto_schema(
+        operation_description="Sync all sources",
+        manual_parameters=[],
+        responses={200: openapi.Response(description="Task ID", schema=openapi.Schema(type=openapi.TYPE_STRING))},
+    )
     def post(self, request, *args, **kwargs):
         task = sync_all_sources.apply_async()
 
@@ -48,7 +53,13 @@ class DataSetListView(ListCreateAPIView):
     serializer_class = DataSetSerializer
     permission_classes = [IsAuthenticated]
 
-    @swagger_auto_schema(operation_description="List data sets", manual_parameters=[])
+    @swagger_auto_schema(
+        operation_description="List data sets",
+        manual_parameters=[],
+    )
+    def get(self, request, *args, **kwargs):
+        return super().get(request, *args, **kwargs)
+
     def get_queryset(self):
         if self.request.user and self.request.user.is_staff:
             return DataSet.objects.all()
@@ -56,6 +67,9 @@ class DataSetListView(ListCreateAPIView):
         return DataSet.objects.filter(users=self.request.user)
 
     @swagger_auto_schema(operation_description="Create a new data set", request_body=DataSetSerializer)
+    def post(self, request, *args, **kwargs):
+        return super().post(request, *args, **kwargs)
+
     def perform_create(self, serializer):
         if not self.request.user.is_staff:
             self.permission_denied(self.request)
@@ -138,6 +152,9 @@ class DataSetUserListView(ListCreateAPIView):
             )
         ],
     )
+    def get(self, request, *args, **kwargs):
+        return super().get(request, *args, **kwargs)
+
     def get_queryset(self):
         return DataSet.objects.get(id=self.kwargs["data_set_id"]).users.all()
 
@@ -148,6 +165,9 @@ class DataSetUserListView(ListCreateAPIView):
             properties={"user_id": openapi.Schema(type=openapi.TYPE_INTEGER, description="ID of the user")},
         ),
     )
+    def post(self, request, *args, **kwargs):
+        return super().post(request, *args, **kwargs)
+
     def create(self, *args, **kwargs):
         user = User.objects.get(id=self.request.data["user_id"])
         DataSet.objects.get(id=self.kwargs["data_set_id"]).users.add(user)
@@ -174,6 +194,11 @@ class DataSetUserView(GenericAPIView):
 class SyncDataSetAllSourcesView(GenericAPIView):
     permission_classes = [IsAdminUser]
 
+    @swagger_auto_schema(
+        operation_description="Sync all sources in a data set",
+        manual_parameters=[],
+        responses={200: openapi.Response(description="Task ID", schema=openapi.Schema(type=openapi.TYPE_STRING))},
+    )
     def post(self, request, *args, **kwargs):
         task = sync_data_set_all_sources.apply_async(args=[kwargs["data_set_id"]])
 
@@ -192,12 +217,18 @@ class DataSetProductSourceListView(ListCreateAPIView):
             )
         ],
     )
+    def get(self, request, *args, **kwargs):
+        return super().get(request, *args, **kwargs)
+
     def get_queryset(self):
         return ProductSource.objects.filter(data_set_id=self.kwargs["data_set_id"])
 
     @swagger_auto_schema(
         operation_description="Create a new product source in a data set", request_body=ProductSourceSerializer
     )
+    def post(self, request, *args, **kwargs):
+        return super().post(request, *args, **kwargs)
+
     def perform_create(self, serializer):
         if not self.request.user and self.request.user.is_staff:
             self.permission_denied(self.request)
@@ -257,6 +288,11 @@ class DataSetProductSourceView(GenericAPIView):
 class SyncAllProductSourcesView(GenericAPIView):
     permission_classes = [IsAdminUser]
 
+    @swagger_auto_schema(
+        operation_description="Sync all product sources",
+        manual_parameters=[],
+        responses={200: openapi.Response(description="Task ID", schema=openapi.Schema(type=openapi.TYPE_STRING))},
+    )
     def post(self, request, *args, **kwargs):
         task = sync_all_product_sources.apply_async()
 
@@ -266,6 +302,11 @@ class SyncAllProductSourcesView(GenericAPIView):
 class SyncDataSetProductSourcesView(GenericAPIView):
     permission_classes = [IsAdminUser]
 
+    @swagger_auto_schema(
+        operation_description="Sync all product sources in a data set",
+        manual_parameters=[],
+        responses={200: openapi.Response(description="Task ID", schema=openapi.Schema(type=openapi.TYPE_STRING))},
+    )
     def post(self, request, *args, **kwargs):
         task = sync_data_set_product_sources.apply_async(args=[kwargs["data_set_id"]])
 
@@ -275,6 +316,11 @@ class SyncDataSetProductSourcesView(GenericAPIView):
 class SyncDataSetProductSourceView(GenericAPIView):
     permission_classes = [IsAdminUser]
 
+    @swagger_auto_schema(
+        operation_description="Sync a product source",
+        manual_parameters=[],
+        responses={200: openapi.Response(description="Task ID", schema=openapi.Schema(type=openapi.TYPE_STRING))},
+    )
     def post(self, request, *args, **kwargs):
         task = sync_product_source.apply_async(args=[kwargs["product_source_id"]])
 
@@ -294,6 +340,9 @@ class ProductListView(ListAPIView):
             )
         ],
     )
+    def get(self, request, *args, **kwargs):
+        return super().get(request, *args, **kwargs)
+
     def get_queryset(self):
         if self.request.user.is_staff:
             data_set = DataSet.objects.get(id=self.kwargs["data_set_id"])
@@ -315,6 +364,9 @@ class DocumentListView(ListAPIView):
             )
         ],
     )
+    def get(self, request, *args, **kwargs):
+        return super().get(request, *args, **kwargs)
+
     def get_queryset(self):
         if self.request.user.is_staff:
             data_set = DataSet.objects.get(id=self.kwargs["data_set_id"])
@@ -335,12 +387,18 @@ class DataSetDocumentSourceListView(ListCreateAPIView):
             )
         ],
     )
+    def get(self, request, *args, **kwargs):
+        return super().get(request, *args, **kwargs)
+
     def get_queryset(self):
         return DocumentSource.objects.filter(data_set_id=self.kwargs["data_set_id"])
 
     @swagger_auto_schema(
         operation_description="Create a new document source in a data set", request_body=DocumentSourceSerializer
     )
+    def post(self, request, *args, **kwargs):
+        return super().post(request, *args, **kwargs)
+
     def perform_create(self, serializer):
         if not self.request.user and self.request.user.is_staff:
             self.permission_denied(self.request)
@@ -406,6 +464,11 @@ class DataSetDocumentSourceView(GenericAPIView):
 class SyncAllDocumentSourcesView(GenericAPIView):
     permission_classes = [IsAdminUser]
 
+    @swagger_auto_schema(
+        operation_description="Sync all document sources",
+        manual_parameters=[],
+        responses={200: openapi.Response(description="Task ID", schema=openapi.Schema(type=openapi.TYPE_STRING))},
+    )
     def post(self, request, *args, **kwargs):
         task = sync_all_document_sources.apply_async()
 
@@ -415,6 +478,11 @@ class SyncAllDocumentSourcesView(GenericAPIView):
 class SyncDataSetDocumentSourcesView(GenericAPIView):
     permission_classes = [IsAdminUser]
 
+    @swagger_auto_schema(
+        operation_description="Sync all document sources in a data set",
+        manual_parameters=[],
+        responses={200: openapi.Response(description="Task ID", schema=openapi.Schema(type=openapi.TYPE_STRING))},
+    )
     def post(self, request, *args, **kwargs):
         task = sync_data_set_document_sources.apply_async(args=[kwargs["data_set_id"]])
 
@@ -424,6 +492,11 @@ class SyncDataSetDocumentSourcesView(GenericAPIView):
 class SyncDataSetDocumentSourceView(GenericAPIView):
     permission_classes = [IsAdminUser]
 
+    @swagger_auto_schema(
+        operation_description="Sync a document source",
+        manual_parameters=[],
+        responses={200: openapi.Response(description="Task ID", schema=openapi.Schema(type=openapi.TYPE_STRING))},
+    )
     def post(self, request, *args, **kwargs):
         task = sync_document_source.apply_async(args=[kwargs["document_source_id"]])
 
@@ -433,6 +506,29 @@ class SyncDataSetDocumentSourceView(GenericAPIView):
 class ConfigView(GenericAPIView):
     permission_classes = [IsAdminUser]
 
+    @swagger_auto_schema(
+        operation_description="Get catalog configuration",
+        responses={
+            200: openapi.Response(
+                description="Catalog configuration",
+                schema=openapi.Schema(
+                    type=openapi.TYPE_OBJECT,
+                    properties={
+                        "language_model_providers": openapi.Schema(
+                            type=openapi.TYPE_ARRAY,
+                            items=openapi.Schema(type=openapi.TYPE_STRING),
+                            description="List of available language model providers"
+                        ),
+                        "embedding_providers": openapi.Schema(
+                            type=openapi.TYPE_ARRAY,
+                            items=openapi.Schema(type=openapi.TYPE_STRING),
+                            description="List of available embedding providers"
+                        ),
+                    },
+                ),
+            )
+        }
+    )
     def get(self, request, *args, **kwargs):
         response_body = {
             "language_model_providers": settings.CATALOG_LANGUAGE_MODEL_PROVIDERS.keys(),
@@ -445,6 +541,18 @@ class ConfigView(GenericAPIView):
 class ConfigLanguageModelView(GenericAPIView):
     permission_classes = [IsAdminUser]
 
+    @swagger_auto_schema(
+        operation_description="Get available language models for a given provider",
+        responses={
+            200: openapi.Response(
+                description="List of available language models",
+                schema=openapi.Schema(
+                    type=openapi.TYPE_ARRAY,
+                    items=openapi.Schema(type=openapi.TYPE_STRING),
+                ),
+            )
+        }
+    )
     def get(self, request, *args, **kwargs):
         provider_name = kwargs.get("provider_name")
         response_body = LanguageModelRegistry().provider_class_by_name(provider_name).available_models()
@@ -455,6 +563,18 @@ class ConfigLanguageModelView(GenericAPIView):
 class ConfigEmbeddingModelView(GenericAPIView):
     permission_classes = [IsAdminUser]
 
+    @swagger_auto_schema(
+        operation_description="Get available embedding models for a given provider",
+        responses={
+            200: openapi.Response(
+                description="List of available embedding models",
+                schema=openapi.Schema(
+                    type=openapi.TYPE_ARRAY,
+                    items=openapi.Schema(type=openapi.TYPE_STRING),
+                ),
+            )
+        }
+    )
     def get(self, request, *args, **kwargs):
         provider_name = kwargs.get("provider_name")
         response_body = EmbeddingProviderRegistry().provider_class_by_name(provider_name).available_models()

--- a/server/sync/views.py
+++ b/server/sync/views.py
@@ -2,7 +2,7 @@ from django.conf import settings
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
-
+from drf_yasg.utils import swagger_auto_schema
 from sync.serializers import SourcePluginSerializer
 
 
@@ -15,6 +15,10 @@ class GetDocumentSourcePlugins(APIView):
     serializer_class = SourcePluginSerializer
     pagination_class = None
 
+    @swagger_auto_schema(
+        operation_description="Get list of document source plugins",
+        responses={200: SourcePluginSerializer(many=True)},
+    )
     def get(self, request):
         plugins = settings.CATALOG_DOCUMENT_SOURCE_PLUGINS.items()
         data = [{"plugin_name": plugin_name} for plugin_name, plugin_class in plugins]
@@ -32,6 +36,10 @@ class GetProductSourcePlugins(APIView):
     serializer_class = SourcePluginSerializer
     pagination_class = None
 
+    @swagger_auto_schema(
+        operation_description="Get list of product source plugins",
+        responses={200: SourcePluginSerializer(many=True)},
+    )
     def get(self, request):
         plugins = settings.CATALOG_PRODUCT_SOURCE_PLUGINS.items()
         data = [{"plugin_name": plugin_name} for plugin_name, plugin_class in plugins]


### PR DESCRIPTION
This PR adds`@swagger_auto_schema` in places it was missing, makes sure this decorator is above right methods (`get`, `post`, etc.) and makes sure to handle manual parameters and response schemas correctly.