### PR TITLE
feat: replace Vite error overlay with user-facing error page

### DIFF
--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -11,6 +11,7 @@ import { LoginPage } from "@/pages/login.tsx";
 import { authenticationProviderInstance } from "@/lib/authentication-provider.ts";
 import { ApiConnectionIndex } from "@/pages/service-accounts/index.tsx";
 import { NoDataSets } from "@/pages/no-data-sets.tsx";
+import { ErrorPage } from "@/pages/error.tsx";
 import { ApiClient } from "@/lib/api.ts";
 import { NewDataSet } from "@/pages/data-sets/new.tsx";
 import { DataSetsIndex } from "@/pages/data-sets";
@@ -54,6 +55,7 @@ const router = createBrowserRouter([
     path: "/",
     element: <App />,
     loader: protectedLoginLoader,
+    errorElement: <ErrorPage />,
     children: [
       {
         path: '/data-sets/:id/products',

--- a/frontend/src/pages/error.tsx
+++ b/frontend/src/pages/error.tsx
@@ -1,0 +1,14 @@
+export function ErrorPage() {
+  return (
+    <div className="flex flex-col items-center justify-center h-screen space-y-4 bg-gray-50 p-6">
+      <h1 className="text-2xl font-bold">Something went wrong</h1>
+      <p className="text-muted-foreground text-center">Please try refreshing the page. If the problem persists, contact your administrator.</p>
+      <button
+        className="mt-2 text-sm underline text-muted-foreground hover:text-foreground"
+        onClick={() => window.location.reload()}
+      >
+        Refresh
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
Added a fallback error page shown when the app encounters an unhandled error (e.g. backend unreachable). Previously this resulted in a raw Vite error overlay being shown to the user.                                                                                                                                                                     
                                                                                                                                                                              
Changes                                                                                                                                                                       
- pages/error.tsx — simple "Something went wrong" page with a refresh link
- main.tsx — wires errorElement on the root route so all loader and component errors are caught 


Demo
<img width="1512" height="843" alt="image" src="https://github.com/user-attachments/assets/aa5aecc8-de68-4802-9a92-6572b6c42710" />
