### PR TITLE
feat: no error display on sync integration and no test connectivity 

### DIFF
--- a/frontend/src/components/data-sets/add-edit-source-modal.tsx
+++ b/frontend/src/components/data-sets/add-edit-source-modal.tsx
@@ -8,6 +8,8 @@ import { useSourceForm } from "./hooks/use-source-form.ts";
 import { ConfigurationForm } from "@/components/ui/configuration-form.tsx";
 import { FormModal } from "@/components/ui/form-modal";
 import { useEffect } from "react";
+import { Button } from "@/components/ui/button.tsx";
+import { Loader2, CheckCircle2, XCircle } from "lucide-react";
 
 const formSchema = z.object({
   pluginName: z.string().min(1, "Plugin is required"),
@@ -49,6 +51,10 @@ export function AddEditSourceModal({
     fieldErrors,
     generalError,
     submitting,
+    testing,
+    testResult,
+    testError,
+    testConnection,
     handleSubmit,
     getSelectedPlugin,
     resetForm
@@ -141,6 +147,31 @@ export function AddEditSourceModal({
               setConfig={setConfig}
               fieldErrors={fieldErrors}
             />
+          )}
+
+          {selectedPlugin && (
+            <div className="space-y-2">
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                disabled={testing || submitting}
+                onClick={testConnection}
+              >
+                {testing && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                Test Connection
+              </Button>
+              {testResult === 'success' && (
+                <p className="flex items-center gap-1.5 text-sm text-green-600">
+                  <CheckCircle2 className="h-4 w-4" /> Connection successful
+                </p>
+              )}
+              {testResult === 'error' && (
+                <p className="flex items-center gap-1.5 text-sm text-destructive">
+                  <XCircle className="h-4 w-4" /> {testError}
+                </p>
+              )}
+            </div>
           )}
         </form>
       </Form>

--- a/frontend/src/components/data-sets/data-set-integration-list.tsx
+++ b/frontend/src/components/data-sets/data-set-integration-list.tsx
@@ -11,9 +11,10 @@ import {
   DropdownMenuTrigger
 } from "@/components/ui/dropdown-menu.tsx";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog.tsx";
-import { Plus, RefreshCw, Settings, Trash2, AlertTriangle } from "lucide-react";
+import { Plus, RefreshCw, Settings, Trash2, AlertTriangle, Loader2 } from "lucide-react";
 import { AddEditSourceModal } from "./add-edit-source-modal.tsx";
 import { ButtonWithTooltip } from "@/components/ui/button-with-tooltip.tsx";
+import { Alert, AlertDescription } from "@/components/ui/alert.tsx";
 
 
 const api = new ApiClient(authenticationProviderInstance);
@@ -36,6 +37,8 @@ export function DataSetIntegrationList({ dataSetId }: DataSetSourceListProps) {
   const [selectedSourceType, setSelectedSourceType] = useState<'product' | 'document' | 'ecommerce'>('product');
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
   const [sourceToDelete, setSourceToDelete] = useState<SourceWithType | null>(null);
+  const [syncError, setSyncError] = useState<string | null>(null);
+  const [syncingKeys, setSyncingKeys] = useState<Set<string>>(new Set());
 
   const loadSources = useCallback(async () => {
     const [integration, productSources, documentSources] = await Promise.all([
@@ -96,13 +99,38 @@ export function DataSetIntegrationList({ dataSetId }: DataSetSourceListProps) {
   };
 
   const handleSyncSource = async (source: SourceWithType) => {
-    if (source.type === 'product') {
-      await api.dataSets().syncDataSetProductSource(dataSetId, source.id);
-    } else if (source.type === 'document') {
-      await api.dataSets().syncDataSetDocumentSource(dataSetId, source.id);
-    } else if (source.type === 'ecommerce') {
-      await api.dataSets().syncDataSetEcommerceIntegration(dataSetId);
+    const sourceKey = `${source.type}-${source.id}`;
+    setSyncError(null);
+    setSyncingKeys(prev => new Set(prev).add(sourceKey));
+
+    let taskId: string;
+    try {
+      if (source.type === 'product') {
+        taskId = await api.dataSets().syncDataSetProductSource(dataSetId, source.id);
+      } else if (source.type === 'document') {
+        taskId = await api.dataSets().syncDataSetDocumentSource(dataSetId, source.id);
+      } else {
+        taskId = await api.dataSets().syncDataSetEcommerceIntegration(dataSetId);
+      }
+    } catch {
+      setSyncError("Failed to start synchronization");
+      setSyncingKeys(prev => { const next = new Set(prev); next.delete(sourceKey); return next; });
+      return;
     }
+
+    const poll = async () => {
+      const result = await api.dataSets().getTaskStatus(taskId);
+      if (result.status === "SUCCESS") {
+        setSyncingKeys(prev => { const next = new Set(prev); next.delete(sourceKey); return next; });
+      } else if (result.status === "FAILURE") {
+        setSyncingKeys(prev => { const next = new Set(prev); next.delete(sourceKey); return next; });
+        setSyncError(result.error || "Synchronization failed");
+      } else {
+        setTimeout(poll, 2000);
+      }
+    };
+
+    setTimeout(poll, 2000);
   };
 
   const handleRemoveSource = (source: SourceWithType) => {
@@ -190,6 +218,12 @@ export function DataSetIntegrationList({ dataSetId }: DataSetSourceListProps) {
         </DropdownMenu>
       </div>
 
+      {syncError && (
+        <Alert variant="destructive">
+          <AlertDescription>{syncError}</AlertDescription>
+        </Alert>
+      )}
+
       {sources.length > 0 ? (
         <Table>
           <TableHeader>
@@ -238,9 +272,11 @@ export function DataSetIntegrationList({ dataSetId }: DataSetSourceListProps) {
                       size="sm"
                       onClick={() => handleSyncSource(source)}
                       tooltip={source.corrupted ? "Cannot sync corrupted source" : "Synchronize data from source"}
-                      disabled={source.corrupted}
+                      disabled={source.corrupted || syncingKeys.has(`${source.type}-${source.id}`)}
                     >
-                      <RefreshCw className="h-4 w-4"/>
+                      {syncingKeys.has(`${source.type}-${source.id}`)
+                        ? <Loader2 className="h-4 w-4 animate-spin" />
+                        : <RefreshCw className="h-4 w-4" />}
                     </ButtonWithTooltip>
                     <ButtonWithTooltip
                       variant="outline"

--- a/frontend/src/components/data-sets/hooks/use-source-form.ts
+++ b/frontend/src/components/data-sets/hooks/use-source-form.ts
@@ -16,6 +16,7 @@ export function useSourceForm(
 ) {
   const [pluginName, setPluginName] = useState("");
   const [config, setConfig] = useState<Record<string, string | number | boolean>>({});
+  const [openSections, setOpenSections] = useState<Record<string, boolean>>({});
   const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
   const [generalError, setGeneralError] = useState<string>("");
   const [submitting, setSubmitting] = useState(false);
@@ -52,6 +53,7 @@ export function useSourceForm(
       if (!source) {
         setPluginName("");
         setConfig({});
+        setOpenSections({});
         setFieldErrors({});
         setGeneralError("");
       }
@@ -61,26 +63,71 @@ export function useSourceForm(
   }, [source]);
 
   useEffect(() => {
-    const selectedPlugin = availablePlugins.find((p) => p.name === pluginName);
-
-    if (!pluginName) {
-      if (!source?.id) {
+    const clearFormWhenNoPlugin = () => {
+      if (!pluginName) {
+        if (source?.id) {
+          return false;
+        }
         setConfig({});
+        setOpenSections({});
+        return true;
       }
-      return;
-    }
+      return false;
+    };
 
-    if (!selectedPlugin) return;
+    const getSelectedPlugin = () => {
+      return availablePlugins.find((p) => p.name === pluginName);
+    };
 
-    if (!source?.id && Object.keys(config).length === 0) {
+    const initializeCollapsedSections = () => {
+      const selectedPlugin = getSelectedPlugin();
+      if (!selectedPlugin) return {};
+
+      const initialOpenSections: Record<string, boolean> = {};
+      if (Object.keys(selectedPlugin.configuration_args).length > 0) {
+        initialOpenSections['configuration'] = true;
+      }
+      return initialOpenSections;
+    };
+
+    const createDefaultConfigValues = () => {
+      const selectedPlugin = getSelectedPlugin();
+      if (!selectedPlugin) return {};
+
       const defaults: Record<string, string | number | boolean> = {};
       Object.entries(selectedPlugin.configuration_args).forEach(([key, schema]) => {
         const configKey = `configuration_${key}`;
-        defaults[configKey] = schema.type.inner_type === 'Json' ? '{}' : '';
+        if (schema.type.inner_type === 'Json') {
+          defaults[configKey] = '{}';
+        } else {
+          defaults[configKey] = '';
+        }
       });
-      setConfig(defaults);
-    }
-  }, [pluginName, availablePlugins, source, config, setConfig]);
+      return defaults;
+    };
+
+    const updateFormForSelectedPlugin = () => {
+      const wasCleared = clearFormWhenNoPlugin();
+      if (wasCleared) {
+        return;
+      }
+
+      const selectedPlugin = getSelectedPlugin();
+      if (!selectedPlugin) {
+        return;
+      }
+
+      const initialOpenSections = initializeCollapsedSections();
+      setOpenSections(initialOpenSections);
+
+      if (!source?.id && Object.keys(config).length === 0) {
+        const defaults = createDefaultConfigValues();
+        setConfig(defaults);
+      }
+    };
+
+    updateFormForSelectedPlugin();
+  }, [pluginName, availablePlugins, source, config, setConfig, setOpenSections]);
 
   const saveSourceToApi = async (configObj: Record<string, unknown>) => {
     if (source) {
@@ -177,6 +224,7 @@ export function useSourceForm(
   const resetForm = () => {
     setPluginName("");
     setConfig({});
+    setOpenSections({});
     setFieldErrors({});
     setGeneralError("");
     setTestResult(null);
@@ -188,6 +236,8 @@ export function useSourceForm(
     setPluginName,
     config,
     setConfig,
+    openSections,
+    setOpenSections,
     fieldErrors,
     generalError,
     submitting,

--- a/frontend/src/components/data-sets/hooks/use-source-form.ts
+++ b/frontend/src/components/data-sets/hooks/use-source-form.ts
@@ -16,10 +16,12 @@ export function useSourceForm(
 ) {
   const [pluginName, setPluginName] = useState("");
   const [config, setConfig] = useState<Record<string, string | number | boolean>>({});
-  const [openSections, setOpenSections] = useState<Record<string, boolean>>({});
   const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
   const [generalError, setGeneralError] = useState<string>("");
   const [submitting, setSubmitting] = useState(false);
+  const [testing, setTesting] = useState(false);
+  const [testResult, setTestResult] = useState<'success' | 'error' | null>(null);
+  const [testError, setTestError] = useState<string>("");
 
   useEffect(() => {
     const loadSourceDetailsForEditing = async () => {
@@ -50,7 +52,6 @@ export function useSourceForm(
       if (!source) {
         setPluginName("");
         setConfig({});
-        setOpenSections({});
         setFieldErrors({});
         setGeneralError("");
       }
@@ -60,71 +61,26 @@ export function useSourceForm(
   }, [source]);
 
   useEffect(() => {
-    const clearFormWhenNoPlugin = () => {
-      if (!pluginName) {
-        if (source?.id) {
-          return false;
-        }
+    const selectedPlugin = availablePlugins.find((p) => p.name === pluginName);
+
+    if (!pluginName) {
+      if (!source?.id) {
         setConfig({});
-        setOpenSections({});
-        return true;
       }
-      return false;
-    };
+      return;
+    }
 
-    const getSelectedPlugin = () => {
-      return availablePlugins.find((p) => p.name === pluginName);
-    };
+    if (!selectedPlugin) return;
 
-    const initializeCollapsedSections = () => {
-      const selectedPlugin = getSelectedPlugin();
-      if (!selectedPlugin) return {};
-
-      const initialOpenSections: Record<string, boolean> = {};
-      if (Object.keys(selectedPlugin.configuration_args).length > 0) {
-        initialOpenSections['configuration'] = true;
-      }
-      return initialOpenSections;
-    };
-
-    const createDefaultConfigValues = () => {
-      const selectedPlugin = getSelectedPlugin();
-      if (!selectedPlugin) return {};
-
+    if (!source?.id && Object.keys(config).length === 0) {
       const defaults: Record<string, string | number | boolean> = {};
       Object.entries(selectedPlugin.configuration_args).forEach(([key, schema]) => {
         const configKey = `configuration_${key}`;
-        if (schema.type.inner_type === 'Json') {
-          defaults[configKey] = '{}';
-        } else {
-          defaults[configKey] = '';
-        }
+        defaults[configKey] = schema.type.inner_type === 'Json' ? '{}' : '';
       });
-      return defaults;
-    };
-
-    const updateFormForSelectedPlugin = () => {
-      const wasCleared = clearFormWhenNoPlugin();
-      if (wasCleared) {
-        return;
-      }
-
-      const selectedPlugin = getSelectedPlugin();
-      if (!selectedPlugin) {
-        return;
-      }
-
-      const initialOpenSections = initializeCollapsedSections();
-      setOpenSections(initialOpenSections);
-      
-      if (!source?.id && Object.keys(config).length === 0) {
-        const defaults = createDefaultConfigValues();
-        setConfig(defaults);
-      }
-    };
-
-    updateFormForSelectedPlugin();
-  }, [pluginName, availablePlugins, source, config, setConfig, setOpenSections]);
+      setConfig(defaults);
+    }
+  }, [pluginName, availablePlugins, source, config, setConfig]);
 
   const saveSourceToApi = async (configObj: Record<string, unknown>) => {
     if (source) {
@@ -197,12 +153,34 @@ export function useSourceForm(
     return availablePlugins.find((p) => p.name === pluginName);
   };
 
+  const testConnection = async () => {
+    setTesting(true);
+    setTestResult(null);
+    setTestError("");
+    try {
+      const configObj = buildConfigFromFlattened(config, { 'configuration': 'configuration_args' });
+      const result = await apiClient.dataSets().testSourceConnection(dataSetId!, sourceType, pluginName, configObj);
+      if (result.error) {
+        setTestResult('error');
+        setTestError(result.error);
+      } else {
+        setTestResult('success');
+      }
+    } catch {
+      setTestResult('error');
+      setTestError("Could not reach the server");
+    } finally {
+      setTesting(false);
+    }
+  };
+
   const resetForm = () => {
     setPluginName("");
     setConfig({});
-    setOpenSections({});
     setFieldErrors({});
     setGeneralError("");
+    setTestResult(null);
+    setTestError("");
   };
 
   return {
@@ -210,11 +188,13 @@ export function useSourceForm(
     setPluginName,
     config,
     setConfig,
-    openSections,
-    setOpenSections,
     fieldErrors,
     generalError,
     submitting,
+    testing,
+    testResult,
+    testError,
+    testConnection,
     handleSubmit,
     getSelectedPlugin,
     resetForm,

--- a/frontend/src/lib/api/data-sets.ts
+++ b/frontend/src/lib/api/data-sets.ts
@@ -164,14 +164,16 @@ export class DataSetsApiClient extends BaseApiClient {
     );
   }
 
-  async syncDataSetProductSource(dataSetId: number, pluginId: number): Promise<void> {
-    await fetch(
+  async syncDataSetProductSource(dataSetId: number, pluginId: number): Promise<string> {
+    const response = await fetch(
       `${this.apiBase}/api/data_sets/${dataSetId}/product_sources/${pluginId}/sync`,
       {
         ...this._requestConfiguration(),
         method: "POST"
       }
     );
+    const body = await response.json();
+    return body.task_id as string;
   }
 
   async removeDataSetProductSource(dataSetId: number, pluginId: number): Promise<void> {
@@ -245,14 +247,16 @@ export class DataSetsApiClient extends BaseApiClient {
     );
   }
 
-  async syncDataSetDocumentSource(dataSetId: number, pluginId: number): Promise<void> {
-    await fetch(
+  async syncDataSetDocumentSource(dataSetId: number, pluginId: number): Promise<string> {
+    const response = await fetch(
       `${this.apiBase}/api/data_sets/${dataSetId}/document_sources/${pluginId}/sync`,
       {
         ...this._requestConfiguration(),
         method: "POST"
       }
     );
+    const body = await response.json();
+    return body.task_id as string;
   }
 
   async removeDataSetDocumentSource(dataSetId: number, pluginId: number): Promise<void> {
@@ -355,14 +359,38 @@ export class DataSetsApiClient extends BaseApiClient {
     );
   }
 
-  async syncDataSetEcommerceIntegration(dataSetId: number): Promise<void> {
-    await fetch(
+  async syncDataSetEcommerceIntegration(dataSetId: number): Promise<string> {
+    const response = await fetch(
       `${this.apiBase}/api/data_sets/${dataSetId}/ecommerce_integration/sync`,
       {
         ...this._requestConfiguration(),
         method: "POST"
       }
     );
+    const body = await response.json();
+    return body.task_id as string;
+  }
+
+  async getTaskStatus(taskId: string): Promise<{ status: string; error?: string }> {
+    const response = await fetch(`${this.apiBase}/api/tasks/${taskId}`, this._requestConfiguration());
+    return await response.json();
+  }
+
+  async testSourceConnection(dataSetId: number, sourceType: 'product' | 'document' | 'ecommerce', pluginName: string, config: object): Promise<{ error?: string }> {
+    const path = sourceType === 'product'
+      ? `product_sources`
+      : sourceType === 'document'
+        ? `document_sources`
+        : `ecommerce_integration`;
+    const response = await fetch(
+      `${this.apiBase}/api/data_sets/${dataSetId}/${path}/test`,
+      {
+        ...this._requestConfiguration(),
+        method: "POST",
+        body: JSON.stringify({ plugin_name: pluginName, config }),
+      }
+    );
+    return await response.json();
   }
 
   async removeDataSetECommerceIntegration(dataSetId: number): Promise<void> {

--- a/server/catalog/urls.py
+++ b/server/catalog/urls.py
@@ -71,6 +71,22 @@ urlpatterns = [
         views.DataSetECommerceIntegrationSyncView.as_view(),
         name="data_set_ecommerce_integration_sync",
     ),
+    path("api/tasks/<str:task_id>", views.TaskStatusView.as_view(), name="task_status"),
+    path(
+        "api/data_sets/<int:data_set_id>/product_sources/test",
+        views.TestProductSourceConnectionView.as_view(),
+        name="test_product_source_connection",
+    ),
+    path(
+        "api/data_sets/<int:data_set_id>/document_sources/test",
+        views.TestDocumentSourceConnectionView.as_view(),
+        name="test_document_source_connection",
+    ),
+    path(
+        "api/data_sets/<int:data_set_id>/ecommerce_integration/test",
+        views.TestECommerceConnectionView.as_view(),
+        name="test_ecommerce_connection",
+    ),
     path("api/config", views.ConfigView.as_view(), name="config"),
     path(
         "api/config/language_model_providers/<str:provider_name>",

--- a/server/catalog/views.py
+++ b/server/catalog/views.py
@@ -1,3 +1,4 @@
+from celery.result import AsyncResult
 from django.db import transaction
 from django.db.models import Count
 from drf_yasg import openapi
@@ -14,6 +15,9 @@ from account.serializers import UserSerializer
 from agent.core.registries.embeddings import EmbeddingProviderRegistry
 from agent.core.registries.language_models import LanguageModelRegistry
 from agent.services import AgentService
+from sync.document.registry import DocumentSourcePluginRegistry
+from sync.ecommerce.registry import ECommerceIntegrationPluginRegistry
+from sync.product.registry import ProductSourcePluginRegistry
 from sync.tasks import (
     sync_all_document_sources,
     sync_all_product_sources,
@@ -592,6 +596,67 @@ class DataSetECommerceIntegrationSyncView(GenericAPIView):
             return Response(serializer.data, status=status.HTTP_202_ACCEPTED)
         except ECommerceIntegration.DoesNotExist:
             return Response({}, status=status.HTTP_404_NOT_FOUND)
+
+
+class TestSourceConnectionView(APIView):
+    permission_classes = [IsAdminUser]
+    registry_class = None
+
+    def post(self, request, data_set_id):
+        plugin_name = request.data.get("plugin_name")
+        config = request.data.get("config", {})
+
+        try:
+            registry = self.registry_class()
+            plugin_class = registry.get_plugin_class_by_name(plugin_name)
+            plugin = plugin_class(data_set_id=data_set_id)
+            plugin.set_runtime_arguments(config)
+            for _ in plugin.fetch():
+                break
+        except Exception as e:
+            return Response({"error": str(e)}, status=status.HTTP_400_BAD_REQUEST)
+
+        return Response({"status": "ok"})
+
+
+class TestProductSourceConnectionView(TestSourceConnectionView):
+    registry_class = ProductSourcePluginRegistry
+
+
+class TestDocumentSourceConnectionView(TestSourceConnectionView):
+    registry_class = DocumentSourcePluginRegistry
+
+
+class TestECommerceConnectionView(APIView):
+    permission_classes = [IsAdminUser]
+
+    def post(self, request, data_set_id):
+        plugin_name = request.data.get("plugin_name")
+        config = request.data.get("config", {})
+
+        try:
+            registry = ECommerceIntegrationPluginRegistry()
+            plugin_class = registry.get_plugin_class_by_name(plugin_name)
+            plugin = plugin_class(data_set_id=data_set_id)
+            plugin.set_runtime_arguments(config)
+            product_source = plugin.build_product_source()
+            for _ in product_source.fetch():
+                break
+        except Exception as e:
+            return Response({"error": str(e)}, status=status.HTTP_400_BAD_REQUEST)
+
+        return Response({"status": "ok"})
+
+
+class TaskStatusView(APIView):
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request, task_id):
+        result = AsyncResult(task_id)
+        data = {"status": result.state}
+        if result.state == "FAILURE":
+            data["error"] = str(result.result)
+        return Response(data)
 
 
 class ConfigView(GenericAPIView):


### PR DESCRIPTION

>[!NOTE]
> Left for further consideration.

**Problem**                                                                                                                                                                       
   
  Two gaps in the Integrations page UX:                                                                                                                                         
                                                            
  1. When a sync fails (e.g. a typo in base_url), the user receives no feedback — the button returns to its default state silently and the error is lost                        
  2. There was no way to verify a source's connectivity before saving configuration, meaning users only discovered misconfiguration after attempting a full sync
                                                                                                                                                                                
  **Solution**                                                  
                                                                                                                                                                                
  - Sync error notification                                   
  When a sync is triggered, the button shows a spinner while the Celery task runs. The frontend polls /api/tasks/<task_id> every 2s until the task completes. On failure, a destructive Alert appears above the sources table with the error message returned by the task.                                                                                
   
  - Test Connection                                                                                                                                                               
  A "Test Connection" button is added to the Add/Edit source modal. It instantiates the plugin with the current config and attempts to fetch data without persisting anything.
  The result is shown inline — green on success, red with the error message on failure. Works for product sources, document sources, and e-commerce integrations.               
                                                            
  Backend changes                                                                                                                                                               
                                                            
  - TaskStatusView — GET /api/tasks/<task_id> returns Celery task state and error string on failure                                                                             
  - TestProductSourceConnectionView, TestDocumentSourceConnectionView, TestECommerceConnectionView — POST /api/data_sets/<id>/{source_type}/test validates connectivity without
  side effects                                                                                                                                                                  
                                                            
  Demo                                                                                                                                                                          
                                                            
  Sync error alert                                                                                                                                                              
            

https://github.com/user-attachments/assets/96494d79-bba9-4652-87fb-2cd33ca51a30

                                                                                                                                                                                              
   
  Test Connection                                                                                                                                                               
                                                            
      

https://github.com/user-attachments/assets/189b81ff-3646-4742-9c3f-9020ea24e5cc

