### PR TITLE
feat: new card redirection in help section

### DIFF
--- a/frontend/src/components/navigation/main-sidebar-menu-dropdown-item.tsx
+++ b/frontend/src/components/navigation/main-sidebar-menu-dropdown-item.tsx
@@ -38,10 +38,7 @@ export function MainSidebarMenuDropdownItem({ item }: MainSidebarMenuDropdownIte
             {item.children.map((child) => {
               return (
                 <DropdownMenuItem asChild key={child.title}>
-                  {child.external
-                    ? <a href={child.link} target="_blank" rel="noopener noreferrer">{child.icon}{child.title}</a>
-                    : <Link to={child.link}>{child.icon}{child.title}</Link>
-                  }
+                  <Link to={child.link} target={child.external ? "_blank" : undefined} rel={child.external ? "noopener noreferrer" : undefined}>{child.icon}{child.title}</Link>
                 </DropdownMenuItem>
               )
             })}

--- a/frontend/src/components/navigation/main-sidebar-menu-dropdown-item.tsx
+++ b/frontend/src/components/navigation/main-sidebar-menu-dropdown-item.tsx
@@ -38,10 +38,10 @@ export function MainSidebarMenuDropdownItem({ item }: MainSidebarMenuDropdownIte
             {item.children.map((child) => {
               return (
                 <DropdownMenuItem asChild key={child.title}>
-                  <Link to={child.link}>
-                    {child.icon}
-                    {child.title}
-                  </Link>
+                  {child.external
+                    ? <a href={child.link} target="_blank" rel="noopener noreferrer">{child.icon}{child.title}</a>
+                    : <Link to={child.link}>{child.icon}{child.title}</Link>
+                  }
                 </DropdownMenuItem>
               )
             })}

--- a/frontend/src/components/navigation/main-sidebar-section.tsx
+++ b/frontend/src/components/navigation/main-sidebar-section.tsx
@@ -11,6 +11,7 @@ export interface SidebarSectionItemProps {
   icon: ReactNode,
   children?: SidebarSectionItemProps[];
   disabled?: boolean;
+  external?: boolean;
 }
 
 export interface SidebarSectionProps {

--- a/frontend/src/components/navigation/main-sidebar.tsx
+++ b/frontend/src/components/navigation/main-sidebar.tsx
@@ -99,13 +99,15 @@ export function MainSidebar() {
           title: "Getting Started",
           link: "https://upsidelab.io/tools/enthusiast/docs/getting-started/import-test-data",
           key: "documentation-getting-started",
-          icon: <SparklesIcon />
+          icon: <SparklesIcon />,
+          external: true
         },
         {
           title: "API Documentation",
           link: `${import.meta.env.VITE_API_BASE}/api/docs`,
           key: "api-documentation",
-          icon: <BookTextIcon />
+          icon: <BookTextIcon />,
+          external: true
         }
       ]
     },


### PR DESCRIPTION
  **Problem**

  Clicking "Getting Started" or "API Documentation" in the Help menu navigated in the same tab, losing the user's current context.

  **Fix**

  Added an external flag to SidebarSectionItemProps. When set, the dropdown renders a plain <a target="_blank"> instead of a React Router <Link>. Both Help menu items are marked as external.