### PR TITLE
fix: Discrepancy in how files are displayed in conversation history

### DIFF
--- a/server/agent/views.py
+++ b/server/agent/views.py
@@ -126,7 +126,7 @@ class ConversationView(APIView):
                     conversation_id=conversation.id,
                     created_at=datetime.now(),
                     type=Message.MessageType.FILE,
-                    file_name=file.file.name.split(".")[0],
+                    file_name=os.path.basename(file.file.name),
                     file_type=file.file.name.split(".")[-1],
                     text=f"Uploaded {file.file.name} with id: {file.pk}",
                 )


### PR DESCRIPTION
  **Problem**                                                                                                                                                                       
  After uploading a file, the attachment bubble showed the correct filename (e.g. my_document.pdf). After page reload, it showed the full Django storage path without extension 
  (e.g. conversations/20/my_document), because file.file.name.split(".")[0] was used when saving the message.
                                                                                                                                                                                
  **Fix**                                                       
  Changed to os.path.basename(file.file.name) so the stored file_name matches what the browser shows immediately after upload. 