### PR TITLE
fix: allow embedding providers define vector size constraints per model

### DIFF
--- a/frontend/src/components/data-sets/data-set-form.tsx
+++ b/frontend/src/components/data-sets/data-set-form.tsx
@@ -9,13 +9,18 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { ChevronDownIcon, ChevronUpIcon } from "lucide-react";
 import { ApiClient } from "@/lib/api.ts";
 import { authenticationProviderInstance } from "@/lib/authentication-provider.ts";
-import { DataSet, ProvidersConfig } from "@/lib/types.ts";
+import { DataSet, EmbeddingModelsConfig, ProvidersConfig } from "@/lib/types.ts";
 import { Alert, AlertDescription } from "@/components/ui/alert.tsx";
 import { InfoIcon } from "lucide-react";
 import { formSchema, DataSetFormSchema } from "./data-set-form-schema.ts";
 import { Label } from "@/components/ui/label.tsx";
 
 const api = new ApiClient(authenticationProviderInstance);
+
+function formatList(items: (string | number)[]): string {
+  if (items.length <= 1) return String(items[0] ?? "");
+  return `${items.slice(0, -1).join(", ")} or ${items[items.length - 1]}`;
+}
 
 interface DataSetFormProps {
   initialData?: DataSet;
@@ -42,7 +47,7 @@ function DisabledFieldMessage() {
 export function DataSetForm({ initialData, onSubmit, submitButtonText, isOnboarding = false, disabledFields = [] }: DataSetFormProps) {
   const [providersConfig, setProvidersConfig] = useState<ProvidersConfig | undefined>(undefined);
   const [languageModelNames, setLanguageModelNames] = useState<string[] | undefined>(undefined);
-  const [embeddingModels, setEmbeddingModels] = useState<string[] | undefined>(undefined);
+  const [embeddingModelsConfig, setEmbeddingModelsConfig] = useState<EmbeddingModelsConfig | undefined>(undefined);
 
   const form = useForm<DataSetFormSchema>({
     resolver: zodResolver(formSchema),
@@ -99,19 +104,30 @@ export function DataSetForm({ initialData, onSubmit, submitButtonText, isOnboard
   useEffect(() => {
     const loadEmbeddingModels = async () => {
       if (embeddingProvider) {
-        setEmbeddingModels(undefined);
+        setEmbeddingModelsConfig(undefined);
         const result = await api.config().getEmbeddingModelsForProvider(embeddingProvider);
-        setEmbeddingModels(result);
-        
+        setEmbeddingModelsConfig(result);
+
         // Set default value if not already set
-        if (!form.getValues('embeddingModel') && result.length > 0) {
-          form.setValue("embeddingModel", result[0]);
+        if (!form.getValues('embeddingModel') && result.models.length > 0) {
+          form.setValue("embeddingModel", result.models[0]);
         }
       }
     }
     loadEmbeddingModels();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [embeddingProvider]);
+
+  const embeddingModel = form.watch('embeddingModel');
+
+  useEffect(() => {
+    if (!embeddingModelsConfig || !embeddingModel) return;
+    const allowedSizes = embeddingModelsConfig.vectorSizeConstraints[embeddingModel];
+    if (allowedSizes && allowedSizes.length > 0) {
+      form.setValue("embeddingVectorSize", allowedSizes[0]);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [embeddingModel, embeddingModelsConfig]);
 
   const [advancedOpen, setAdvancedOpen] = useState<boolean>(false);
 
@@ -242,16 +258,16 @@ export function DataSetForm({ initialData, onSubmit, submitButtonText, isOnboard
                   <FormItem>
                     <FormLabel>Embedding Model</FormLabel>
                     <Select value={field.value} onValueChange={field.onChange} defaultValue={field.value}>
-                      <SelectTrigger disabled={!embeddingModels || disabledFields.includes('embeddingModel')}>
+                      <SelectTrigger disabled={!embeddingModelsConfig || disabledFields.includes('embeddingModel')}>
                         <FormControl>
                           <SelectValue placeholder="Select a model for embeddings"/>
                         </FormControl>
                       </SelectTrigger>
                       <SelectContent>
                         {
-                          embeddingModels &&
+                          embeddingModelsConfig &&
                           <>
-                            {embeddingModels.map((modelName) => (
+                            {embeddingModelsConfig.models.map((modelName) => (
                               <SelectItem key={modelName} value={modelName}>{modelName}</SelectItem>
                             ))}
                           </>
@@ -262,20 +278,47 @@ export function DataSetForm({ initialData, onSubmit, submitButtonText, isOnboard
                   </FormItem>
                 )}
               />
-              <FormField
-                control={form.control}
-                name="embeddingVectorSize"
-                disabled={disabledFields.includes('embeddingVectorSize')}
-                render={({field}) => (
-                  <FormItem>
-                    <FormLabel>Vector Size</FormLabel>
-                    <FormControl>
-                      <Input {...field} />
-                    </FormControl>
-                    <FormDescription>The size of the embedding vector to use</FormDescription>
-                  </FormItem>
-                )}
-              />
+              {(() => {
+                const allowedSizes = embeddingModelsConfig?.vectorSizeConstraints[embeddingModel ?? ""];
+                const isConstrained = allowedSizes && allowedSizes.length > 0;
+                const isDisabled = disabledFields.includes('embeddingVectorSize');
+                return (
+                  <FormField
+                    control={form.control}
+                    name="embeddingVectorSize"
+                    disabled={isDisabled || isConstrained}
+                    render={({field}) => (
+                      <FormItem>
+                        <FormLabel>Vector Size</FormLabel>
+                        <FormControl>
+                          {isConstrained && !isDisabled ? (
+                            <Select
+                              value={String(field.value)}
+                              onValueChange={(v) => field.onChange(Number(v))}
+                            >
+                              <SelectTrigger>
+                                <SelectValue />
+                              </SelectTrigger>
+                              <SelectContent>
+                                {allowedSizes.map((size) => (
+                                  <SelectItem key={size} value={String(size)}>{size}</SelectItem>
+                                ))}
+                              </SelectContent>
+                            </Select>
+                          ) : (
+                            <Input {...field} />
+                          )}
+                        </FormControl>
+                        <FormDescription>
+                          {isConstrained
+                            ? `This model only supports a fixed vector size of ${formatList(allowedSizes)}.`
+                            : "The size of the embedding vector to use"}
+                        </FormDescription>
+                      </FormItem>
+                    )}
+                  />
+                );
+              })()}
             </div>
           </CollapsibleContent>
         </Collapsible>

--- a/frontend/src/lib/api/config.ts
+++ b/frontend/src/lib/api/config.ts
@@ -1,9 +1,14 @@
 import { BaseApiClient } from "@/lib/api/base.ts";
-import { ProvidersConfig } from "@/lib/types.ts";
+import { EmbeddingModelsConfig, ProvidersConfig } from "@/lib/types.ts";
 
 type ProvidersConfigResponse = {
   language_model_providers: string[];
   embedding_providers: string[];
+};
+
+type EmbeddingModelsConfigResponse = {
+  models: string[];
+  vector_size_constraints: Record<string, number[]>;
 };
 
 export class ConfigApiClient extends BaseApiClient {
@@ -22,8 +27,13 @@ export class ConfigApiClient extends BaseApiClient {
     return await response.json() as string[];
   }
 
-  async getEmbeddingModelsForProvider(name: string): Promise<string[]> {
+  async getEmbeddingModelsForProvider(name: string): Promise<EmbeddingModelsConfig> {
     const response = await fetch(`${this.apiBase}/api/config/embedding_providers/${name}`, this._requestConfiguration());
-    return await response.json() as string[];
+    const result = await response.json() as EmbeddingModelsConfigResponse;
+
+    return {
+      models: result.models,
+      vectorSizeConstraints: result.vector_size_constraints,
+    };
   }
 }

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -99,6 +99,11 @@ export type ProvidersConfig = {
   embeddingProviders: string[];
 }
 
+export type EmbeddingModelsConfig = {
+  models: string[];
+  vectorSizeConstraints: Record<string, number[]>;
+}
+
 export type TypeInfo = {
   container: string | null;
   inner_type?: string;

--- a/plugins/enthusiast-common/enthusiast_common/registry/embeddings.py
+++ b/plugins/enthusiast-common/enthusiast_common/registry/embeddings.py
@@ -35,6 +35,21 @@ class EmbeddingProvider(ABC):
             A list of supported model names.
         """
 
+    @classmethod
+    def vector_size_constraints(cls) -> dict[str, list[int]]:
+        """Returns a mapping of model name to allowed vector sizes.
+
+        Override this method in provider subclasses when specific models only
+        support a fixed set of output dimensions (e.g. models that do not accept
+        an ``output_dimension`` parameter).  An empty dict (the default) means no
+        constraints — any positive integer is accepted.
+
+        Returns:
+            A dict mapping model name to a list of allowed vector sizes, e.g.
+            ``{"mistral-embed": [1024]}``.  Return ``{}`` when unconstrained.
+        """
+        return {}
+
 
 class BaseEmbeddingProviderRegistry(ABC):
     """Registry of available embedding providers.

--- a/plugins/enthusiast-model-mistral/enthusiast_model_mistral/embedding.py
+++ b/plugins/enthusiast-model-mistral/enthusiast_model_mistral/embedding.py
@@ -6,6 +6,13 @@ from mistralai import Mistral
 
 PRIORITIZED_MODELS = ["mistral-embed"]
 
+# These models produce a fixed-size output vector and do not accept the
+# output_dimension parameter in the Mistral embeddings API.
+FIXED_DIMENSION_MODELS: dict[str, list[int]] = {
+    "mistral-embed": [1024],
+    "mistral-embed-2312": [1024],
+}
+
 
 class MistralAIEmbeddingProvider(EmbeddingProvider):
     NAME = "Mistral AI"
@@ -18,9 +25,12 @@ class MistralAIEmbeddingProvider(EmbeddingProvider):
             content (str): The input text for which the embedding vector is to be generated.
         """
         client = Mistral(api_key=os.environ["MISTRAL_API_KEY"])
-        mistral_embedding = client.embeddings.create(
-            inputs=content, output_dimension=self._dimensions, model=self._model
-        )
+
+        kwargs = {"inputs": content, "model": self._model}
+        if self._model not in FIXED_DIMENSION_MODELS:
+            kwargs["output_dimension"] = self._dimensions
+
+        mistral_embedding = client.embeddings.create(**kwargs)
 
         return mistral_embedding.data[0].embedding
 
@@ -30,3 +40,7 @@ class MistralAIEmbeddingProvider(EmbeddingProvider):
         all_models = client.models.list().data
         embedding_models = [model.id for model in all_models if "embed" in model.id]
         return prioritize_items(embedding_models, PRIORITIZED_MODELS)
+
+    @classmethod
+    def vector_size_constraints(cls) -> dict[str, list[int]]:
+        return FIXED_DIMENSION_MODELS

--- a/server/catalog/serializers.py
+++ b/server/catalog/serializers.py
@@ -1,6 +1,7 @@
 from rest_framework import serializers
 from utils.serializers import ParentDataContextSerializerMixin
 
+from agent.core.registries.embeddings.embedding_provider_registry import EmbeddingProviderRegistry
 from sync.document.registry import DocumentSourcePluginRegistry
 from sync.product.registry import ProductSourcePluginRegistry
 
@@ -26,6 +27,33 @@ class DataSetCreateSerializer(DataSetSerializer):
 
     class Meta(DataSetSerializer.Meta):
         fields = DataSetSerializer.Meta.fields + ["preconfigure_agents"]
+
+    def validate(self, data):
+        """Validate that embedding_vector_dimensions satisfies provider constraints."""
+        embedding_provider = data.get("embedding_provider")
+        embedding_model = data.get("embedding_model")
+        embedding_vector_dimensions = data.get("embedding_vector_dimensions")
+
+        if embedding_provider and embedding_model and embedding_vector_dimensions is not None:
+            try:
+                provider_class = EmbeddingProviderRegistry().provider_class_by_name(embedding_provider)
+            except Exception:
+                provider_class = None
+
+            if provider_class is not None:
+                constraints = provider_class.vector_size_constraints()
+                allowed_sizes = constraints.get(embedding_model)
+                if allowed_sizes and embedding_vector_dimensions not in allowed_sizes:
+                    raise serializers.ValidationError(
+                        {
+                            "embedding_vector_dimensions": (
+                                f"Model '{embedding_model}' only supports vector sizes: "
+                                f"{allowed_sizes}. Got {embedding_vector_dimensions}."
+                            )
+                        }
+                    )
+
+        return data
 
 
 class ProductSerializer(serializers.ModelSerializer):

--- a/server/catalog/tests/test_views/test_data_set_list_view.py
+++ b/server/catalog/tests/test_views/test_data_set_list_view.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from django.test import override_settings
@@ -8,6 +8,7 @@ from pydantic import Field
 from rest_framework import status
 
 from agent.core.registries.agents.agent_registry import AgentRegistry
+from agent.core.registries.embeddings.embedding_provider_registry import EmbeddingProviderRegistry
 from agent.models import Agent
 from catalog.models import DataSet
 
@@ -78,3 +79,41 @@ class TestDataSetListViewPost:
         mock_agent_registry.assert_called()
 
         assert Agent.objects.filter(dataset=dataset).exists()
+
+    @patch.object(EmbeddingProviderRegistry, "provider_class_by_name")
+    def test_dataset_creation_with_constrained_vector_size_success(
+        self, mock_provider_class_by_name, admin_api_client, url
+    ):
+        mock_provider = MagicMock()
+        mock_provider.vector_size_constraints.return_value = {"constrained-embed": [1024]}
+        mock_provider_class_by_name.return_value = mock_provider
+
+        payload = {
+            "name": "Constrained DataSet",
+            "embedding_provider": "MockProvider",
+            "embedding_model": "constrained-embed",
+            "embedding_vector_dimensions": 1024,
+        }
+        response = admin_api_client.post(url, payload, format="json")
+
+        assert response.status_code == status.HTTP_201_CREATED
+        assert DataSet.objects.filter(name="Constrained DataSet").exists()
+
+    @patch.object(EmbeddingProviderRegistry, "provider_class_by_name")
+    def test_dataset_creation_with_constrained_vector_size_failure(
+        self, mock_provider_class_by_name, admin_api_client, url
+    ):
+        mock_provider = MagicMock()
+        mock_provider.vector_size_constraints.return_value = {"constrained-embed": [1024]}
+        mock_provider_class_by_name.return_value = mock_provider
+
+        payload = {
+            "name": "Constrained DataSet",
+            "embedding_provider": "MockProvider",
+            "embedding_model": "constrained-embed",
+            "embedding_vector_dimensions": 512,
+        }
+        response = admin_api_client.post(url, payload, format="json")
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert not DataSet.objects.filter(name="Constrained DataSet").exists()

--- a/server/catalog/views.py
+++ b/server/catalog/views.py
@@ -659,19 +659,40 @@ class ConfigEmbeddingModelView(GenericAPIView):
     permission_classes = [IsAdminUser]
 
     @swagger_auto_schema(
-        operation_description="Get available embedding models for a given provider",
+        operation_description="Get available embedding models and vector size constraints for a given provider",
         responses={
             200: openapi.Response(
-                description="List of available embedding models",
+                description="Embedding models config",
                 schema=openapi.Schema(
-                    type=openapi.TYPE_ARRAY,
-                    items=openapi.Schema(type=openapi.TYPE_STRING),
+                    type=openapi.TYPE_OBJECT,
+                    properties={
+                        "models": openapi.Schema(
+                            type=openapi.TYPE_ARRAY,
+                            items=openapi.Schema(type=openapi.TYPE_STRING),
+                            description="List of available embedding model names",
+                        ),
+                        "vector_size_constraints": openapi.Schema(
+                            type=openapi.TYPE_OBJECT,
+                            description=(
+                                "Map of model name to allowed vector sizes. "
+                                "Empty object means no constraints."
+                            ),
+                            additional_properties=openapi.Schema(
+                                type=openapi.TYPE_ARRAY,
+                                items=openapi.Schema(type=openapi.TYPE_INTEGER),
+                            ),
+                        ),
+                    },
                 ),
             )
         },
     )
     def get(self, request, *args, **kwargs):
         provider_name = kwargs.get("provider_name")
-        response_body = EmbeddingProviderRegistry().provider_class_by_name(provider_name).available_models()
+        provider_class = EmbeddingProviderRegistry().provider_class_by_name(provider_name)
+        response_body = {
+            "models": provider_class.available_models(),
+            "vector_size_constraints": provider_class.vector_size_constraints(),
+        }
 
         return Response(response_body)


### PR DESCRIPTION
Issue came up when testing Mistral AI.

Text embedding models do not support defining custom output dimensions (all returned vectors are of 1024 length). Executing the code: 
```python
        mistral_embedding = client.embeddings.create(
            inputs=content, output_dimension=self._dimensions, model=self._model
        )
```
caused SDK to raise error with this API response body:
```json
{
    "object":"error",
    "message":"This model does not support output_dimension.",
    "type":"invalid_request_invalid_args",
    "param":null,
    "code":"3051",
    "raw_status_code":400
}
```

What is interesting, code dedicated embedding models do not have this constraint ([reference 1](https://docs.mistral.ai/capabilities/embeddings/text_embeddings), [reference 2](https://docs.mistral.ai/capabilities/embeddings/code_embeddings)).

The fix I proposed tackles this by allowing Embedding Providers to override the interfaces method `vector_size_constraints`. This method provides the model_name -> allowed vector sizes list hash map (if no model_name in the returned hash keys, there is no constraints on the database vector size). 

The constraint is enforced:
- on FE form (select form with allowed sizes)
- on BE (dataset creation validation)
