### PR TITLE
fix: Ollama LLM provider fixes

### DIFF
--- a/plugins/enthusiast-common/enthusiast_common/registry/llm.py
+++ b/plugins/enthusiast-common/enthusiast_common/registry/llm.py
@@ -55,7 +55,6 @@ class LanguageModelProvider(ABC):
 
     @classmethod
     def prepare_files_objects(cls, files_objects: list[LLMFile]):
-        pass
         objects = []
         for file in files_objects:
             if file.file_category == FileTypes.FILE.value:

--- a/plugins/enthusiast-model-ollama/enthusiast_model_ollama/embedding.py
+++ b/plugins/enthusiast-model-ollama/enthusiast_model_ollama/embedding.py
@@ -18,7 +18,7 @@ class OllamaEmbeddingProvider(EmbeddingProvider):
 
     @staticmethod
     def available_models() -> list[str]:
-        all_model_names = map(lambda m: m.model, Client().list().models)
+        all_model_names = [m.model for m in Client().list().models]
         embedding_models = [
             model_name for model_name in all_model_names
                         if model_name and OllamaEmbeddingProvider.is_embedding_model(model_name)

--- a/plugins/enthusiast-model-ollama/enthusiast_model_ollama/embedding.py
+++ b/plugins/enthusiast-model-ollama/enthusiast_model_ollama/embedding.py
@@ -18,6 +18,14 @@ class OllamaEmbeddingProvider(EmbeddingProvider):
 
     @staticmethod
     def available_models() -> list[str]:
-        all_models = Client().list().models
-        embedding_models = [model.name for model in all_models if model.name.contains("embed")]
+        all_model_names = map(lambda m: m.model, Client().list().models)
+        embedding_models = [
+            model_name for model_name in all_model_names
+                        if model_name and OllamaEmbeddingProvider.is_embedding_model(model_name)
+        ]
         return embedding_models
+
+
+    @staticmethod
+    def is_embedding_model(model_name: str) -> bool:
+        return 'embed' in model_name

--- a/plugins/enthusiast-model-ollama/enthusiast_model_ollama/language_model.py
+++ b/plugins/enthusiast-model-ollama/enthusiast_model_ollama/language_model.py
@@ -1,104 +1,26 @@
-from typing import Callable
-
 from enthusiast_common.registry.llm import LanguageModelProvider
 from enthusiast_common.structures import BaseContent, LLMFile
 from langchain_core.callbacks import BaseCallbackHandler
 from langchain_core.language_models import BaseLanguageModel
 from langchain_ollama import ChatOllama
 from ollama import Client
-from pydantic import ConfigDict
 
 from .embedding import OllamaEmbeddingProvider
 
 
-class OllamaFileObject(BaseContent):
-    model_config = ConfigDict(extra="allow")
+class OllamaImageContent(BaseContent):
+    type: str = "image_url"
+    image_url: str
 
 
-class OllamaPrepareFileMapper:
-    @staticmethod
-    def gpt_image(file_object: LLMFile) -> OllamaFileObject:
-        image_url = f'data:{file_object.content_type};base64,"{file_object.content}"'
-        return OllamaFileObject(
-            type="input_image",
-            image_url=image_url,
-        )
-
-    @staticmethod
-    def gpt_file(file_object: LLMFile) -> OllamaFileObject:
-        file_data = file_object.content
-        return OllamaFileObject(
-            type="input_file",
-            file_data=file_data,
-            filename=file_object.filename,
-        )
-
-    @staticmethod
-    def mistral_image(file_object: LLMFile) -> OllamaFileObject:
-        image_url = f"data:{file_object.content_type};base64,{file_object.content}"
-        return OllamaFileObject(
-            type="image_url",
-            image_url=image_url,
-        )
-
-    @staticmethod
-    def mistral_file(file_object: LLMFile) -> OllamaFileObject:
-        document_url = f"data:{file_object.content_type};base64,{file_object.content}"
-        return OllamaFileObject(
-            type="document_url",
-            document_url=document_url,
-        )
-
-    @staticmethod
-    def gemma_image(file_object: LLMFile) -> OllamaFileObject:
-        image_url = f"data:{file_object.content_type};base64,{file_object.content}"
-        return OllamaFileObject(
-            type="image_url",
-            image_url=image_url,
-        )
-
-    @staticmethod
-    def gemma_file(file_object: LLMFile) -> OllamaFileObject:
-        data = file_object.content
-        return OllamaFileObject(
-            type="input_file",
-            data=data,
-            mime_type=file_object.content_type,
-        )
-
-    MODEL_MAPPING: dict[str, dict[str, Callable[[LLMFile], OllamaFileObject]]] = {
-        "gpt": {
-            "image": gpt_image.__func__,
-            "file": gpt_file.__func__,
-        },
-        "mistral": {
-            "image": mistral_image.__func__,
-            "file": mistral_file.__func__,
-        },
-        "gemma": {
-            "image": gemma_image.__func__,
-            "file": gemma_file.__func__,
-        },
-    }
-
-    def get_prepare_file_function(self, model: str, file_type: str) -> Callable[[LLMFile], OllamaFileObject]:
-        family_matches = [key for key in self.MODEL_MAPPING.keys() if model.startswith(key)]
-        if not family_matches:
-            raise ValueError(f"Model {model} not supported.")
-        model_family = family_matches[0]
-        model_object = self.MODEL_MAPPING.get(model_family)
-        if not model_object:
-            raise ValueError(f"Model {model} not supported.")
-        prepare_file_function = model_object.get(file_type)
-        if not prepare_file_function:
-            raise ValueError(f"Invalid file type {file_type} for model {model}.")
-        return prepare_file_function
+class OllamaFileContent(BaseContent):
+    type: str = "document_url"
+    document_url: str
 
 
 class OllamaLanguageModelProvider(LanguageModelProvider):
     NAME = "Ollama"
     STREAMING_AVAILABLE = False
-    MODEL_MAPPING_CLASS = OllamaPrepareFileMapper
 
     def provide_language_model(self, callbacks: list[BaseCallbackHandler] | None = None) -> BaseLanguageModel:
         return ChatOllama(model=self._model)
@@ -115,8 +37,12 @@ class OllamaLanguageModelProvider(LanguageModelProvider):
         ]
         return llm_models
 
-    def prepare_image_object(self, file_object: LLMFile) -> OllamaFileObject:
-        return self.MODEL_MAPPING_CLASS().get_prepare_file_function(model=self._model, file_type="image")(file_object)
+    @staticmethod
+    def prepare_image_object(file_object: LLMFile) -> OllamaImageContent:
+        image_url = f"data:{file_object.content_type};base64,{file_object.content}"
+        return OllamaImageContent(image_url=image_url)
 
-    def prepare_file_object(self, file_object: LLMFile) -> OllamaFileObject:
-        return self.MODEL_MAPPING_CLASS().get_prepare_file_function(model=self._model, file_type="file")(file_object)
+    @staticmethod
+    def prepare_file_object(file_object: LLMFile) -> OllamaFileContent:
+        document_url = f"data:{file_object.content_type};base64,{file_object.content}"
+        return OllamaFileContent(document_url=document_url)

--- a/plugins/enthusiast-model-ollama/enthusiast_model_ollama/language_model.py
+++ b/plugins/enthusiast-model-ollama/enthusiast_model_ollama/language_model.py
@@ -25,7 +25,7 @@ class OllamaLanguageModelProvider(LanguageModelProvider):
 
     @staticmethod
     def available_models() -> list[str]:
-        all_model_names = map(lambda m: m.model, Client().list().models)
+        all_model_names = [m.model for m in Client().list().models]
         llm_models = [
             model_name for model_name in all_model_names
                         if model_name and not OllamaEmbeddingProvider.is_embedding_model(model_name)

--- a/plugins/enthusiast-model-ollama/enthusiast_model_ollama/language_model.py
+++ b/plugins/enthusiast-model-ollama/enthusiast_model_ollama/language_model.py
@@ -13,11 +13,6 @@ class OllamaImageContent(BaseContent):
     image_url: str
 
 
-class OllamaFileContent(BaseContent):
-    type: str = "document_url"
-    document_url: str
-
-
 class OllamaLanguageModelProvider(LanguageModelProvider):
     NAME = "Ollama"
     STREAMING_AVAILABLE = False
@@ -43,6 +38,5 @@ class OllamaLanguageModelProvider(LanguageModelProvider):
         return OllamaImageContent(image_url=image_url)
 
     @staticmethod
-    def prepare_file_object(file_object: LLMFile) -> OllamaFileContent:
-        document_url = f"data:{file_object.content_type};base64,{file_object.content}"
-        return OllamaFileContent(document_url=document_url)
+    def prepare_file_object(_):
+        raise NotImplementedError("Ollama does not support document file inputs.")

--- a/plugins/enthusiast-model-ollama/enthusiast_model_ollama/language_model.py
+++ b/plugins/enthusiast-model-ollama/enthusiast_model_ollama/language_model.py
@@ -8,6 +8,8 @@ from langchain_ollama import ChatOllama
 from ollama import Client
 from pydantic import ConfigDict
 
+from .embedding import OllamaEmbeddingProvider
+
 
 class OllamaFileObject(BaseContent):
     model_config = ConfigDict(extra="allow")
@@ -106,8 +108,12 @@ class OllamaLanguageModelProvider(LanguageModelProvider):
 
     @staticmethod
     def available_models() -> list[str]:
-        ollama_client = Client()
-        return [model.model for model in ollama_client.list().models]
+        all_model_names = map(lambda m: m.model, Client().list().models)
+        llm_models = [
+            model_name for model_name in all_model_names
+                        if model_name and not OllamaEmbeddingProvider.is_embedding_model(model_name)
+        ]
+        return llm_models
 
     def prepare_image_object(self, file_object: LLMFile) -> OllamaFileObject:
         return self.MODEL_MAPPING_CLASS().get_prepare_file_function(model=self._model, file_type="image")(file_object)


### PR DESCRIPTION
PR introduces fixes for Ollama LLMs:
- `embedding_models = [model.name for model in all_models if model.name.contains("embed")]` was crashing - models do not have "name" property - they do have "model" property. Additionally I unified how the embedding and llm models are being selected - with embedding providers being filtered out from llm models.
- `prepare_image_object` and `prepare_file_object` were instance methods instead of static methods (which caused enthusiast to crash on files for ollama providers). I refactored this + removed the whole model check at runtime. Image format should be unified across model providers (ones that accept image input). The `prepare_file_object` implementation is purely for satisfying the interface - I could not find any Ollama model that would accept any other file input besides images.