### PR TITLE
fix: missing file upload messages in agentic execution conversations

### DIFF
--- a/server/agent/agentic_execution/services.py
+++ b/server/agent/agentic_execution/services.py
@@ -96,4 +96,4 @@ class AgenticExecutionService:
             llm_content=llm_content,
             is_hidden=False,
         )
-        ConversationFileMessageService().create_for_file(conversation_file)
+        ConversationFileMessageService.create_for_file(conversation_file)

--- a/server/agent/agentic_execution/services.py
+++ b/server/agent/agentic_execution/services.py
@@ -6,6 +6,7 @@ from django.core.files.uploadedfile import UploadedFile
 
 from agent.agentic_execution.registry import AgenticExecutionDefinitionRegistry
 from agent.agentic_execution.tasks import run_agentic_execution_task
+from agent.conversation_file_message_service import ConversationFileMessageService
 from agent.file_service import FileService
 from agent.models.agent import Agent
 from agent.models.agentic_execution import AgenticExecution
@@ -88,7 +89,7 @@ class AgenticExecutionService:
         )
         django_file = ContentFile(f.read(), name=f.name)
         llm_content = FileService(django_file, content_type).process() or ""
-        ConversationFile.objects.create(
+        conversation_file = ConversationFile.objects.create(
             conversation=conversation,
             file=django_file,
             file_category=file_category,
@@ -96,3 +97,4 @@ class AgenticExecutionService:
             llm_content=llm_content,
             is_hidden=False,
         )
+        ConversationFileMessageService().create_for_file(conversation_file)

--- a/server/agent/agentic_execution/services.py
+++ b/server/agent/agentic_execution/services.py
@@ -6,11 +6,10 @@ from django.core.files.uploadedfile import UploadedFile
 
 from agent.agentic_execution.registry import AgenticExecutionDefinitionRegistry
 from agent.agentic_execution.tasks import run_agentic_execution_task
-from agent.conversation_file_message_service import ConversationFileMessageService
-from agent.file_service import FileService
 from agent.models.agent import Agent
 from agent.models.agentic_execution import AgenticExecution
 from agent.models.conversation import Conversation, ConversationFile
+from agent.services import ConversationFileMessageService, FileParsingService
 from pecl import settings
 
 User = get_user_model()
@@ -88,7 +87,7 @@ class AgenticExecutionService:
             else ConversationFile.FileCategory.FILE
         )
         django_file = ContentFile(f.read(), name=f.name)
-        llm_content = FileService(django_file, content_type).process() or ""
+        llm_content = FileParsingService(django_file, content_type).process() or ""
         conversation_file = ConversationFile.objects.create(
             conversation=conversation,
             file=django_file,

--- a/server/agent/agentic_execution/tests/test_services.py
+++ b/server/agent/agentic_execution/tests/test_services.py
@@ -14,6 +14,7 @@ from agent.agentic_execution.services import (
 from agent.models.agent import Agent
 from agent.models.agentic_execution import AgenticExecution
 from agent.models.conversation import ConversationFile
+from agent.models.message import Message
 from catalog.models import DataSet
 
 pytestmark = pytest.mark.django_db
@@ -134,3 +135,32 @@ class TestStart:
         execution = service.start(agent=agent, user=user, execution_key="dummy", validated_input={}, uploaded_files=[])
 
         assert ConversationFile.objects.filter(conversation=execution.conversation).count() == 0
+
+    def test_creates_file_message_for_each_uploaded_file(self, service, agent, user):
+        files = [_make_file("doc.pdf"), _make_file("sheet.txt")]
+        with patch("agent.agentic_execution.services.settings.FILE_PARSER_CLASSES", SUPPORTED_EXTENSIONS), \
+             patch("agent.agentic_execution.services.FileService.process", return_value=""):
+            execution = service.start(
+                agent=agent, user=user, execution_key="dummy", validated_input={}, uploaded_files=files
+            )
+
+        messages = Message.objects.filter(
+            conversation=execution.conversation, type=Message.MessageType.FILE
+        )
+        assert messages.count() == 2
+
+    def test_file_message_has_correct_name_and_type(self, service, agent, user):
+        with patch("agent.agentic_execution.services.settings.FILE_PARSER_CLASSES", SUPPORTED_EXTENSIONS), \
+             patch("agent.agentic_execution.services.FileService.process", return_value=""):
+            execution = service.start(
+                agent=agent, user=user, execution_key="dummy", validated_input={}, uploaded_files=[_make_file("report.pdf")]
+            )
+
+        message = Message.objects.get(conversation=execution.conversation, type=Message.MessageType.FILE)
+        assert message.file_type == "pdf"
+        assert "report" in message.file_name
+
+    def test_no_file_messages_created_when_no_files(self, service, agent, user):
+        execution = service.start(agent=agent, user=user, execution_key="dummy", validated_input={}, uploaded_files=[])
+
+        assert Message.objects.filter(conversation=execution.conversation, type=Message.MessageType.FILE).count() == 0

--- a/server/agent/agentic_execution/tests/test_services.py
+++ b/server/agent/agentic_execution/tests/test_services.py
@@ -109,7 +109,7 @@ class TestStart:
 
     def test_attaches_files_as_conversation_files(self, service, agent, user):
         with patch("agent.agentic_execution.services.settings.FILE_PARSER_CLASSES", SUPPORTED_EXTENSIONS), \
-             patch("agent.agentic_execution.services.FileService.process", return_value="extracted"):
+             patch("agent.agentic_execution.services.FileParsingService.process", return_value="extracted"):
             execution = service.start(
                 agent=agent, user=user, execution_key="dummy", validated_input={}, uploaded_files=[_make_file()]
             )
@@ -123,7 +123,7 @@ class TestStart:
 
     def test_detects_image_file_category(self, service, agent, user):
         with patch("agent.agentic_execution.services.settings.FILE_PARSER_CLASSES", {(".jpg",): "some.Class"}), \
-             patch("agent.agentic_execution.services.FileService.process", return_value=""):
+             patch("agent.agentic_execution.services.FileParsingService.process", return_value=""):
             execution = service.start(
                 agent=agent, user=user, execution_key="dummy", validated_input={}, uploaded_files=[_make_file("photo.jpg", content_type="image/jpeg")]
             )
@@ -139,7 +139,7 @@ class TestStart:
     def test_creates_file_message_for_each_uploaded_file(self, service, agent, user):
         files = [_make_file("doc.pdf"), _make_file("sheet.txt")]
         with patch("agent.agentic_execution.services.settings.FILE_PARSER_CLASSES", SUPPORTED_EXTENSIONS), \
-             patch("agent.agentic_execution.services.FileService.process", return_value=""):
+             patch("agent.agentic_execution.services.FileParsingService.process", return_value=""):
             execution = service.start(
                 agent=agent, user=user, execution_key="dummy", validated_input={}, uploaded_files=files
             )
@@ -151,7 +151,7 @@ class TestStart:
 
     def test_file_message_has_correct_name_and_type(self, service, agent, user):
         with patch("agent.agentic_execution.services.settings.FILE_PARSER_CLASSES", SUPPORTED_EXTENSIONS), \
-             patch("agent.agentic_execution.services.FileService.process", return_value=""):
+             patch("agent.agentic_execution.services.FileParsingService.process", return_value=""):
             execution = service.start(
                 agent=agent, user=user, execution_key="dummy", validated_input={}, uploaded_files=[_make_file("report.pdf")]
             )

--- a/server/agent/conversation_file_message_service.py
+++ b/server/agent/conversation_file_message_service.py
@@ -1,0 +1,27 @@
+from datetime import datetime
+
+from agent.models.conversation import ConversationFile
+from agent.models.message import Message
+
+
+class ConversationFileMessageService:
+    """Creates the FILE message that surfaces an attached file in the conversation history."""
+
+    def create_for_file(self, conversation_file: ConversationFile) -> Message:
+        """Create a FILE message for the given ConversationFile.
+
+        Args:
+            conversation_file: The already-persisted ConversationFile to create a message for.
+
+        Returns:
+            The newly created Message record.
+        """
+        file_name = conversation_file.file.name
+        return Message.objects.create(
+            conversation_id=conversation_file.conversation_id,
+            created_at=datetime.now(),
+            type=Message.MessageType.FILE,
+            file_name=file_name.rsplit(".", 1)[0],
+            file_type=file_name.rsplit(".", 1)[-1],
+            text=f"Uploaded {file_name} with id: {conversation_file.pk}",
+        )

--- a/server/agent/services/__init__.py
+++ b/server/agent/services/__init__.py
@@ -1,0 +1,9 @@
+from .agent_preconfiguration_service import AgentPreconfigurationService
+from .conversation_file_message_service import ConversationFileMessageService
+from .file_parsing_service import FileParsingService
+
+__all__ = [
+    "AgentPreconfigurationService",
+    "ConversationFileMessageService",
+    "FileParsingService",
+]

--- a/server/agent/services/agent_preconfiguration_service.py
+++ b/server/agent/services/agent_preconfiguration_service.py
@@ -11,10 +11,10 @@ from catalog.models import DataSet
 logger = logging.getLogger("AgentService")
 
 
-class AgentService:
+class AgentPreconfigurationService:
     @staticmethod
     def preconfigure_available_agents(data_set: DataSet):
-        registry = AgentService._get_registry()
+        registry = AgentPreconfigurationService._get_registry()
 
         for agent_class in registry.get_plugin_classes():
             if Agent.all_objects.filter(dataset=data_set, agent_type=agent_class.AGENT_KEY).exists():
@@ -23,7 +23,7 @@ class AgentService:
             data = {
                 "name": agent_class.NAME,
                 "description": '',
-                "config": AgentService._build_default_agent_configuration(agent_class),
+                "config": AgentPreconfigurationService._build_default_agent_configuration(agent_class),
                 "dataset": data_set.pk,
                 "agent_type": agent_class.AGENT_KEY,
             }

--- a/server/agent/services/conversation_file_message_service.py
+++ b/server/agent/services/conversation_file_message_service.py
@@ -5,17 +5,8 @@ from agent.models.message import Message
 
 
 class ConversationFileMessageService:
-    """Creates the FILE message that surfaces an attached file in the conversation history."""
-
-    def create_for_file(self, conversation_file: ConversationFile) -> Message:
-        """Create a FILE message for the given ConversationFile.
-
-        Args:
-            conversation_file: The already-persisted ConversationFile to create a message for.
-
-        Returns:
-            The newly created Message record.
-        """
+    @staticmethod
+    def create_for_file(conversation_file: ConversationFile) -> Message:
         file_name = conversation_file.file.name
         return Message.objects.create(
             conversation_id=conversation_file.conversation_id,

--- a/server/agent/services/file_parsing_service.py
+++ b/server/agent/services/file_parsing_service.py
@@ -5,7 +5,7 @@ from enthusiast_common.services.file import BaseFileParser, BaseFileService, Not
 from pecl import settings
 
 
-class FileService(BaseFileService):
+class FileParsingService(BaseFileService):
     def process(self) -> str:
         parser = self._get_parser()
         return parser.parse_content(self.file)

--- a/server/agent/tasks.py
+++ b/server/agent/tasks.py
@@ -8,10 +8,10 @@ from django.utils import timezone
 
 from agent.conversation import ConversationManager
 from agent.core.callbacks import BaseWebSocketHandler
-from agent.file_service import FileService
 from agent.models import Message
 from agent.models.conversation import Conversation, ConversationFile
 from agent.serializers.conversation import ConversationFileSerializer
+from agent.services import FileParsingService
 from pecl import settings
 
 
@@ -77,7 +77,7 @@ def process_file_upload_task(conversation_id: int, file_content: bytes, filename
             file=django_file,
             content_type=content_type,
             file_category=file_category,
-            llm_content=FileService(django_file, content_type).process() or "",
+            llm_content=FileParsingService(django_file, content_type).process() or "",
         )
 
         obj.save()

--- a/server/agent/tests/test_services.py
+++ b/server/agent/tests/test_services.py
@@ -8,7 +8,7 @@ from pydantic import Field
 
 from agent.core.registries.agents.agent_registry import AgentRegistry
 from agent.models import Agent
-from agent.services import AgentService
+from agent.services import AgentPreconfigurationService
 from catalog.models import DataSet
 
 pytestmark = pytest.mark.django_db
@@ -78,7 +78,7 @@ def django_settings(settings):
     ]
 
 
-class TestAgentService:
+class TestAgentPreconfigurationService:
     @pytest.fixture
     def dataset(self):
         return DataSet.objects.create(name="Test Dataset")
@@ -96,7 +96,7 @@ class TestAgentService:
     ):
         mock_agent_registry.return_value = [agent_class]
 
-        AgentService.preconfigure_available_agents(dataset)
+        AgentPreconfigurationService.preconfigure_available_agents(dataset)
 
         agent = Agent.objects.filter(dataset=dataset).first()
         assert agent
@@ -107,7 +107,7 @@ class TestAgentService:
     def test_preconfigure_available_agents_skip_agents_without_defaults(self, mock_agent_registry, dataset):
         mock_agent_registry.return_value = [MockAgentClassWithoutDefaults]
 
-        AgentService.preconfigure_available_agents(dataset)
+        AgentPreconfigurationService.preconfigure_available_agents(dataset)
         assert Agent.objects.filter(dataset=dataset).count() == 0
 
     @patch.object(AgentRegistry, "get_plugin_classes")
@@ -121,6 +121,6 @@ class TestAgentService:
         )
         mock_agent_registry.return_value = [MockAgentClass]
 
-        AgentService.preconfigure_available_agents(dataset)
+        AgentPreconfigurationService.preconfigure_available_agents(dataset)
 
         assert Agent.objects.filter(dataset=dataset, agent_type="dummy_agent").count() == 1

--- a/server/agent/views.py
+++ b/server/agent/views.py
@@ -1,5 +1,4 @@
 import os
-from datetime import datetime
 
 from celery.result import AsyncResult
 from django.conf import settings
@@ -17,6 +16,7 @@ from rest_framework.views import APIView
 from utils.functions import get_model_descriptor_from_class_field
 
 from agent.conversation import ConversationManager
+from agent.conversation_file_message_service import ConversationFileMessageService
 from agent.core.registries.agents.agent_registry import AgentRegistry
 from agent.core.registries.language_models import LanguageModelRegistry
 from agent.core.repositories import DjangoDataSetRepository
@@ -121,15 +121,9 @@ class ConversationView(APIView):
 
         if file_ids := serializer.validated_data.get("file_ids"):
             files = ConversationFile.objects.filter(conversation_id=conversation_id, pk__in=file_ids, is_hidden=True)
+            file_message_service = ConversationFileMessageService()
             for file in files:
-                Message.objects.create(
-                    conversation_id=conversation.id,
-                    created_at=datetime.now(),
-                    type=Message.MessageType.FILE,
-                    file_name=os.path.basename(file.file.name),
-                    file_type=file.file.name.split(".")[-1],
-                    text=f"Uploaded {file.file.name} with id: {file.pk}",
-                )
+                file_message_service.create_for_file(file)
                 file.is_hidden = False
                 file.save()
 

--- a/server/agent/views.py
+++ b/server/agent/views.py
@@ -121,9 +121,8 @@ class ConversationView(APIView):
 
         if file_ids := serializer.validated_data.get("file_ids"):
             files = ConversationFile.objects.filter(conversation_id=conversation_id, pk__in=file_ids, is_hidden=True)
-            file_message_service = ConversationFileMessageService()
             for file in files:
-                file_message_service.create_for_file(file)
+                ConversationFileMessageService.create_for_file(file)
                 file.is_hidden = False
                 file.save()
 

--- a/server/agent/views.py
+++ b/server/agent/views.py
@@ -16,7 +16,6 @@ from rest_framework.views import APIView
 from utils.functions import get_model_descriptor_from_class_field
 
 from agent.conversation import ConversationManager
-from agent.conversation_file_message_service import ConversationFileMessageService
 from agent.core.registries.agents.agent_registry import AgentRegistry
 from agent.core.registries.language_models import LanguageModelRegistry
 from agent.core.repositories import DjangoDataSetRepository
@@ -39,6 +38,7 @@ from agent.serializers.conversation import (
     MessageFeedbackSerializer,
     SupportedFileTypesSerializer,
 )
+from agent.services import ConversationFileMessageService
 from agent.tasks import process_file_upload_task, respond_to_user_message_task
 from catalog.models import DataSet
 

--- a/server/catalog/views.py
+++ b/server/catalog/views.py
@@ -13,7 +13,7 @@ from account.models import User
 from account.serializers import UserSerializer
 from agent.core.registries.embeddings import EmbeddingProviderRegistry
 from agent.core.registries.language_models import LanguageModelRegistry
-from agent.services import AgentService
+from agent.services import AgentPreconfigurationService
 from sync.tasks import (
     sync_all_document_sources,
     sync_all_product_sources,
@@ -83,7 +83,7 @@ class DataSetListView(ListCreateAPIView):
             data_set = serializer.save()
             data_set.users.add(self.request.user)
             if preconfigure_agents:
-                AgentService.preconfigure_available_agents(data_set)
+                AgentPreconfigurationService.preconfigure_available_agents(data_set)
 
 
 class DataSetDetailView(RetrieveAPIView):


### PR DESCRIPTION
PR fixes an issue described in task [ENT-264](https://linear.app/enthusiast/issue/ENT-264/missing-file-upload-messages-in-agentic-execution-conversations-bug).

Additionally, since I extracted the message creation to a separate service (I wanted to use the same logic twice in code) I noticed that this is the third service file existing in the `server/agents` module - that's why I decided to refactor services for that module, by providing the `server/agents/services` module where those services are contained + giving them a bit more meaningful names (`FileService` -> `FileParsingService`, `AgentService` -> `AgentPreconfigurationService`)