### PR TITLE
feat: add scraping support for anti-bot protected sites using curl_cffi

### DIFF
--- a/plugins/enthusiast-agent-product-web-scraper/pyproject.toml
+++ b/plugins/enthusiast-agent-product-web-scraper/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     "enthusiast-agent-tool-calling (>=1.1.0)",
     "enthusiast-agent-catalog-enrichment (>=1.3.0,<2.0.0)",
     "beautifulsoup4 (>=4.14.2,<5.0.0)",
-    "requests (>=2.32.0,<3.0.0)",
+    "curl_cffi (>=0.7.0,<1.0.0)",
 ]
 
 [project.urls]

--- a/plugins/enthusiast-agent-product-web-scraper/src/enthusiast_agent_product_web_scraper/tools/scrape_product_tool.py
+++ b/plugins/enthusiast-agent-product-web-scraper/src/enthusiast_agent_product_web_scraper/tools/scrape_product_tool.py
@@ -1,24 +1,17 @@
 import logging
 
-import requests
 from bs4 import BeautifulSoup
+from curl_cffi import requests as curl_requests
+from curl_cffi.requests import RequestsError
 from enthusiast_common.tools import BaseLLMTool
 from enthusiast_common.utils import RequiredFieldsModel
 from langchain_core.messages import HumanMessage, SystemMessage
 from pydantic import BaseModel, Field
-from requests import HTTPError
 
 logger = logging.getLogger(__name__)
 
 _MINIMAL_CONTENT_THRESHOLD = 300
-_REQUEST_HEADERS = {
-    "User-Agent": (
-        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
-        "AppleWebKit/537.36 (KHTML, like Gecko) "
-        "Chrome/124.0.0.0 Safari/537.36"
-    ),
-    "Accept-Language": "en-US,en;q=0.9",
-}
+_CHROME_IMPERSONATION = "chrome124"
 
 
 class ScrapeProductInput(BaseModel):
@@ -47,16 +40,18 @@ class ScrapeProductConfig(RequiredFieldsModel):
 class ScrapeProductTool(BaseLLMTool):
     """Fetches a product web page and extracts structured product data from it using an LLM.
 
-    Uses plain HTTP requests and BeautifulSoup for content extraction. JavaScript-rendered
-    pages (SPAs) may return minimal content — in that case the tool returns a warning so the
-    agent can relay it to the user.
+    Uses curl_cffi to impersonate a Chrome browser at the TLS level, bypassing basic
+    bot-detection systems. BeautifulSoup strips HTML to plain text which is then passed
+    to an LLM sub-call for field extraction. JavaScript-rendered pages (SPAs) may still
+    return minimal content — in that case the tool returns a warning so the agent can
+    relay it to the user.
     """
 
     NAME = "scrape_product_data"
     DESCRIPTION = (
         "Fetches a product web page from the given URL and extracts product data from its content. "
         "Provide the URL and a description of what data to extract and any format requirements. "
-        "Does not support JavaScript-rendered pages — static HTML only."
+        "Uses Chrome TLS impersonation to bypass basic bot detection."
     )
     ARGS_SCHEMA = ScrapeProductInput
     RETURN_DIRECT = False
@@ -73,7 +68,12 @@ class ScrapeProductTool(BaseLLMTool):
             Extracted field values as a string, or an informative error/warning message.
         """
         try:
-            response = requests.get(url, headers=_REQUEST_HEADERS, proxies=self._get_proxies(), timeout=15)
+            response = curl_requests.get(
+                url,
+                proxies=self._get_proxies(),
+                timeout=15,
+                impersonate=_CHROME_IMPERSONATION,
+            )
             response.raise_for_status()
 
             soup = BeautifulSoup(response.text, "html.parser")
@@ -88,12 +88,10 @@ class ScrapeProductTool(BaseLLMTool):
 
             return self._extract_from_text(page_text, action)
 
-        except HTTPError as e:
-            return f"Could not reach the provided URL (HTTP {e.response.status_code}): {url}"
-        except requests.exceptions.ConnectionError:
-            return f"Connection error — could not reach: {url}"
-        except requests.exceptions.Timeout:
-            return f"Request timed out after 15 seconds: {url}"
+        except RequestsError as e:
+            if e.response is not None:
+                return f"Could not reach the provided URL (HTTP {e.response.status_code}): {url}"
+            return f"Could not reach the provided URL: {url}"
         except Exception as e:
             logger.error("Unexpected error fetching %s: %s", url, e)
             return "Internal error — could not fetch or extract data from the page."


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                           
                                                            
  Resolves [ENT-269](https://linear.app/enthusiast/issue/ENT-269/add-scraping-support-for-anti-bot-protected-sites)                                                                                                                                                                                                                     
   
  Replaces `requests` with `curl_cffi` in `FetchAndExtractProductDataTool` to bypass                                                                                                                                                   
  basic bot-detection systems that block standard Python HTTP clients at the TLS level.
                                                                                                                                                                                                                                       
  Previously, sites using Cloudflare, DataDome, or similar systems could identify the                                                                                                                                                  
  scraper immediately from the TLS fingerprint of `python-requests`, regardless of the                                                                                                                                                 
  User-Agent header. `curl_cffi` impersonates a real Chrome 124 browser at the TLS                                                                                                                                                     
  handshake level, making the traffic indistinguishable from a regular browser request.                                                                                                                                                
                                                                                                                                                                                                                                       
  **Verified working:** Modivo (DataDome-like protected site) — previously returned 403,                                                                                                                                                    
  now returns full product page content.                                                                                                                                                                                               
                                                                                                                                                                                                                                       
  ### Changes                                               

  - Replaced `requests` with `curl_cffi.requests` and added `impersonate="chrome124"`                                                                                                                                                  
  - Removed manual `_REQUEST_HEADERS` (User-Agent, Accept-Language) — curl_cffi sets
    the full Chrome header set automatically as part of impersonation                                                                                                                                                                  
  - Simplified exception handling to a single `RequestsError` (covers HTTP errors,
    connection errors, and timeouts)                                                                                                                                                                                                   
  - Added `_CHROME_IMPERSONATION = "chrome124"` constant for easy version updates
  - Updated `pyproject.toml`: replaced `requests` with `curl_cffi (>=0.7.0,<1.0.0)`                                                                                                                                                    
                                                            
  ## Known limitations                                                                                                                                                                                                                 
                                                            
  **JavaScript-rendered pages** — curl_cffi performs a plain HTTP request and returns                                                                                                                                                  
  raw HTML. Sites that load product data dynamically via JavaScript (SPAs) will still
  return minimal content. The existing JS rendering warning in the tool covers this case,                                                                                                                                              
  but the underlying limitation remains. Playwright-based rendering would be required                                                                                                                                                  
  to solve this properly.                                                                                                                                                                                                              
                                                                                                                                                                                                                                       
  **Behavioural analysis** — sophisticated anti-bot systems (DataDome, PerimeterX) analyse                                                                                                                                             
  traffic patterns beyond TLS fingerprinting: request timing, absence of cookies from a                                                                                                                                                
  prior browsing session, no JavaScript execution signals. curl_cffi does not address these.                                                                                                                                           
  It bypasses the TLS check but may still be detected on sites with aggressive behavioural                                                                                                                                             
  profiling.       
                                                                                                                                                                                                                    
  **IP-based blocking** — curl_cffi does not rotate IPs. High-volume scraping from a single                                                                                                                                            
  IP will eventually trigger rate limiting or bans regardless of TLS impersonation. The tool                                                                                                                                           
  already supports proxy configuration via the `proxy` field in agent settings — pointing it                                                                                                                                           
  at a rotating residential or mobile proxy is sufficient to address this.                                                                                                                                                                     
                                                                                                                                                                                                                                       
  ## Potential next steps                                                                                                                                                                                                              
                                                                                                                                                                                                                                       
  If curl_cffi proves insufficient for a specific site, the next options worth evaluating are:                                                                                                                                         
                                                            
  - **Playwright + stealth patches** — real browser execution, solves JS rendering,
    stealth patches reduce automation signals. Heavier dependency (requires Chromium                                                                                                                                                   
    installed in Docker), slower per request due to browser startup overhead,
    memory-intensive in Celery worker context. Still detectable by advanced systems.                                                                                                                                                   
    Best fit for JS-heavy sites where curl_cffi returns minimal content.                                                                                                                                                                                
                                                                                                                                                                            
  - **curl_cffi + rotating residential proxy** — keeps the current lightweight approach                                                                                                                                                
    but adds IP rotation via the existing `proxy` configuration field          

- **Playwright + curl_cffi as separate backends** — use curl_cffi as default (fast,                                                                                                                                                  
    lightweight, anti-bot), fall back to Playwright when JS rendering is required.                                                                                                                                                     
    Controlled via a `use_browser: bool` flag in `CONFIGURATION_ARGS`. Two separate                                                                                                                                                    
    fetch paths in the tool — no shared integration layer between them.                                                                                                                                                                                                                         
                  
  ## Further reading                                                                                                                                                                                                                   
                                                                                                                                                                                                                                       
  - [Web Scraping Tools Comparison 2026: requests vs curl_cffi vs Playwright vs Scrapy](https://dev.to/vhub_systems_ed5641f65d59/web-scraping-tools-comparison-2026-requests-vs-curlcffi-vs-playwright-vs-scrapy-2fad)                 
  - [curl_cffi for Web Scraping](https://medium.com/@datajournal/curl-cffi-for-web-scraping-a34523f9fe89)                                                                                                                              
  - [Playwright Stealth — Bypass Bot Detection](https://scrapfly.io/blog/posts/playwright-stealth-bypass-bot-detection)    
  - [curl_cffi in python](https://medium.com/@dimakynal/http-3-with-python-and-curl-cffi-a-modern-approach-to-web-requests-b0642fbc5a6f)