### PR TITLE
chore: update GitHub lint pipeline to run ruff check inside the plugins

### DIFF
--- a/.github/workflows/Lint.yml
+++ b/.github/workflows/Lint.yml
@@ -22,13 +22,11 @@ jobs:
       - name: Run Ruff on server
         uses: astral-sh/ruff-action@v3
         with:
-          version: "0.15.9"
           args: "check server"
 
       - name: Run Ruff on plugins
         uses: astral-sh/ruff-action@v3
         with:
-          version: "0.15.9"
           args: "check plugins"
 
   lint-frontend:

--- a/.github/workflows/Lint.yml
+++ b/.github/workflows/Lint.yml
@@ -19,14 +19,17 @@ jobs:
         with:
           python-version: '3.12'
 
-      - name: Install Ruff
-        run: pip install ruff
-
       - name: Run Ruff on server
-        run: ruff check server
+        uses: astral-sh/ruff-action@v3
+        with:
+          version: "0.15.9"
+          args: "check server"
 
       - name: Run Ruff on plugins
-        run: for dir in plugins/*/; do echo "Checking $dir" && ruff check "$dir"; done
+        uses: astral-sh/ruff-action@v3
+        with:
+          version: "0.15.9"
+          args: "check plugins"
 
   lint-frontend:
       runs-on: ubuntu-latest

--- a/.github/workflows/Lint.yml
+++ b/.github/workflows/Lint.yml
@@ -22,8 +22,11 @@ jobs:
       - name: Install Ruff
         run: pip install ruff
 
-      - name: Run Ruff
+      - name: Run Ruff on server
         run: ruff check server
+
+      - name: Run Ruff on plugins
+        run: for dir in plugins/*/; do echo "Checking $dir" && ruff check "$dir"; done
 
   lint-frontend:
       runs-on: ubuntu-latest

--- a/.github/workflows/Lint.yml
+++ b/.github/workflows/Lint.yml
@@ -22,11 +22,13 @@ jobs:
       - name: Run Ruff on server
         uses: astral-sh/ruff-action@v3
         with:
+          version: "0.15.9"
           args: "check server"
 
       - name: Run Ruff on plugins
         uses: astral-sh/ruff-action@v3
         with:
+          version: "0.15.9"
           args: "check plugins"
 
   lint-frontend:

--- a/plugins/enthusiast-agent-catalog-enrichment/src/enthusiast_agent_catalog_enrichment/agent.py
+++ b/plugins/enthusiast-agent-catalog-enrichment/src/enthusiast_agent_catalog_enrichment/agent.py
@@ -1,8 +1,9 @@
 from enthusiast_agent_tool_calling import BaseToolCallingAgent
-from enthusiast_common.utils import RequiredFieldsModel
 from enthusiast_common.config.base import LLMToolConfig
-from .tools.upsert_product_details_tool import UpsertProductDetailsTool
+from enthusiast_common.utils import RequiredFieldsModel
 from pydantic import Field, Json
+
+from .tools.upsert_product_details_tool import UpsertProductDetailsTool
 
 
 class ExtractDataPromptInput(RequiredFieldsModel):

--- a/plugins/enthusiast-agent-catalog-enrichment/src/enthusiast_agent_catalog_enrichment/config.py
+++ b/plugins/enthusiast-agent-catalog-enrichment/src/enthusiast_agent_catalog_enrichment/config.py
@@ -2,7 +2,7 @@ from enthusiast_common.agents import BaseAgentConfigProvider, ConfigType
 from enthusiast_common.config import AgentConfigWithDefaults
 
 from .agent import CatalogEnrichmentAgent
-from .prompt import CATALOG_ENRICHMENT_TOOL_CALLING_AGENT_PROMPT, CATALOG_ENRICHMENT_EXECUTION_SYSTEM_PROMPT
+from .prompt import CATALOG_ENRICHMENT_EXECUTION_SYSTEM_PROMPT, CATALOG_ENRICHMENT_TOOL_CALLING_AGENT_PROMPT
 
 
 class CatalogEnrichmentConfigProvider(BaseAgentConfigProvider):

--- a/plugins/enthusiast-agent-catalog-enrichment/src/enthusiast_agent_catalog_enrichment/execution_definition.py
+++ b/plugins/enthusiast-agent-catalog-enrichment/src/enthusiast_agent_catalog_enrichment/execution_definition.py
@@ -6,6 +6,7 @@ from enthusiast_common.agentic_execution import (
     ExecutionInputType,
 )
 
+
 class CatalogEnrichmentAgenticExecutionInput(ExecutionInputType):
     """Input for the catalog enrichment agentic execution."""
     additional_instructions: Optional[str] = None

--- a/plugins/enthusiast-agent-catalog-enrichment/src/enthusiast_agent_catalog_enrichment/tools/upsert_product_details_tool.py
+++ b/plugins/enthusiast-agent-catalog-enrichment/src/enthusiast_agent_catalog_enrichment/tools/upsert_product_details_tool.py
@@ -1,6 +1,6 @@
-import logging
 import json
-from typing import Optional, List
+import logging
+from typing import List, Optional
 
 from enthusiast_common import ProductDetails
 from enthusiast_common.connectors import ECommercePlatformConnector

--- a/plugins/enthusiast-agent-order-intake/src/enthusiast_agent_order_intake/agent.py
+++ b/plugins/enthusiast-agent-order-intake/src/enthusiast_agent_order_intake/agent.py
@@ -1,6 +1,6 @@
+from enthusiast_agent_product_search.tools import ProductExamplesTool, ProductSQLSearchTool
 from enthusiast_agent_tool_calling import BaseToolCallingAgent
 from enthusiast_common.config.base import LLMToolConfig
-from enthusiast_agent_product_search.tools import ProductExamplesTool, ProductSQLSearchTool
 
 from .tools.place_order_tool import PlaceOrderTool
 

--- a/plugins/enthusiast-agent-order-intake/src/enthusiast_agent_order_intake/config.py
+++ b/plugins/enthusiast-agent-order-intake/src/enthusiast_agent_order_intake/config.py
@@ -4,6 +4,7 @@ from enthusiast_common.config import AgentConfigWithDefaults
 from .agent import OrderIntakeAgent
 from .prompt import ORDER_INTAKE_TOOL_CALLING_AGENT_PROMPT
 
+
 class OrderIntakeConfigProvider(BaseAgentConfigProvider):
     def get_config(self, config_type: ConfigType = ConfigType.CONVERSATION) -> AgentConfigWithDefaults:
         return AgentConfigWithDefaults(

--- a/plugins/enthusiast-agent-order-intake/src/enthusiast_agent_order_intake/tools/__init__.py
+++ b/plugins/enthusiast-agent-order-intake/src/enthusiast_agent_order_intake/tools/__init__.py
@@ -1,1 +1,3 @@
 from .place_order_tool import PlaceOrderTool
+
+__all__ = ["PlaceOrderTool",]

--- a/plugins/enthusiast-agent-product-search/src/enthusiast_agent_product_search/agent.py
+++ b/plugins/enthusiast-agent-product-search/src/enthusiast_agent_product_search/agent.py
@@ -1,8 +1,7 @@
 from enthusiast_agent_tool_calling import BaseToolCallingAgent
 from enthusiast_common.config.base import LLMToolConfig
 
-from .tools import ProductExamplesTool
-from .tools import ProductSQLSearchTool
+from .tools import ProductExamplesTool, ProductSQLSearchTool
 
 
 class ProductSearchAgent(BaseToolCallingAgent):

--- a/plugins/enthusiast-agent-product-search/src/enthusiast_agent_product_search/tools/product_sql_search_tool.py
+++ b/plugins/enthusiast-agent-product-search/src/enthusiast_agent_product_search/tools/product_sql_search_tool.py
@@ -1,7 +1,7 @@
 import json
 
-from enthusiast_common.tools import BaseLLMTool
 from enthusiast_common.errors import RetrieverError
+from enthusiast_common.tools import BaseLLMTool
 from pydantic import BaseModel, Field
 
 

--- a/plugins/enthusiast-agent-tool-calling/src/enthusiast_agent_tool_calling/base_tool_calling_agent.py
+++ b/plugins/enthusiast-agent-tool-calling/src/enthusiast_agent_tool_calling/base_tool_calling_agent.py
@@ -1,12 +1,11 @@
 from typing import Any
 
-from langchain_core.chat_history import BaseChatMessageHistory
-from langgraph.graph.state import CompiledStateGraph
-
 from enthusiast_common.agents import BaseAgent
 from langchain.agents import create_agent
-from langchain_core.messages import AIMessage, HumanMessage, trim_messages, BaseMessage
+from langchain_core.chat_history import BaseChatMessageHistory
+from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, trim_messages
 from langchain_core.tools import BaseTool
+from langgraph.graph.state import CompiledStateGraph
 
 MAX_HISTORY_TOKENS = 3000
 

--- a/plugins/enthusiast-agent-user-manual-search/src/enthusiast_agent_user_manual_search/agent.py
+++ b/plugins/enthusiast-agent-user-manual-search/src/enthusiast_agent_user_manual_search/agent.py
@@ -1,8 +1,7 @@
 from enthusiast_agent_tool_calling import BaseToolCallingAgent
 from enthusiast_common.config.base import LLMToolConfig
 
-from .tools import RetrieveDocumentsTool
-from .tools import VerifySolutionTool
+from .tools import RetrieveDocumentsTool, VerifySolutionTool
 
 
 class UserManualSearchAgent(BaseToolCallingAgent):

--- a/plugins/enthusiast-common/enthusiast_common/injectors/base.py
+++ b/plugins/enthusiast-common/enthusiast_common/injectors/base.py
@@ -3,7 +3,7 @@ from typing import Optional
 
 from enthusiast_common.connectors import ECommercePlatformConnector
 from enthusiast_common.retrievers import BaseProductRetriever, BaseVectorStoreRetriever
-from enthusiast_common.structures import RepositoriesInstances, DocumentChunkDetails
+from enthusiast_common.structures import DocumentChunkDetails, RepositoriesInstances
 from langchain_core.chat_history import BaseChatMessageHistory
 
 

--- a/plugins/enthusiast-common/enthusiast_common/interfaces.py
+++ b/plugins/enthusiast-common/enthusiast_common/interfaces.py
@@ -1,9 +1,9 @@
-from abc import ABC, abstractmethod, ABCMeta
+from abc import ABC, ABCMeta, abstractmethod
 from typing import Any
 
 from enthusiast_common.connectors import ECommercePlatformConnector
 from enthusiast_common.structures import DocumentDetails, ProductDetails
-from enthusiast_common.utils import validate_required_vars, RequiredFieldsModel
+from enthusiast_common.utils import RequiredFieldsModel, validate_required_vars
 
 
 class ExtraArgsClassBaseMeta(ABCMeta):

--- a/plugins/enthusiast-common/enthusiast_common/retrievers/base_product_retriever.py
+++ b/plugins/enthusiast-common/enthusiast_common/retrievers/base_product_retriever.py
@@ -1,6 +1,7 @@
 from abc import ABC, abstractmethod
 
 from enthusiast_common import ProductDetails
+
 from .base import BaseRetriever
 
 

--- a/plugins/enthusiast-common/enthusiast_common/retrievers/vector_store.py
+++ b/plugins/enthusiast-common/enthusiast_common/retrievers/vector_store.py
@@ -3,6 +3,7 @@ from typing import Any, Generic, Iterable, TypeVar
 
 from enthusiast_common.registry import BaseEmbeddingProviderRegistry
 from enthusiast_common.repositories import BaseDataSetRepository, BaseModelChunkRepository
+
 from .base import BaseRetriever
 
 T = TypeVar("T")

--- a/plugins/enthusiast-common/enthusiast_common/structures/product_update_details.py
+++ b/plugins/enthusiast-common/enthusiast_common/structures/product_update_details.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 from typing import Optional
 
+
 @dataclass
 class ProductUpdateDetails:
     name: Optional[str] = None

--- a/plugins/enthusiast-common/enthusiast_common/tools/files/perform_file_operation_tool.py
+++ b/plugins/enthusiast-common/enthusiast_common/tools/files/perform_file_operation_tool.py
@@ -1,7 +1,6 @@
+from enthusiast_common.tools import BaseFileTool
 from langchain_core.messages import HumanMessage, SystemMessage
 from pydantic import BaseModel, Field
-
-from enthusiast_common.tools import BaseFileTool
 
 
 class FileRetrievalToolInput(BaseModel):

--- a/plugins/enthusiast-source-medusa/enthusiast_source_medusa/medusa_platform_connector.py
+++ b/plugins/enthusiast-source-medusa/enthusiast_source_medusa/medusa_platform_connector.py
@@ -1,5 +1,5 @@
-import logging
 import json
+import logging
 from typing import Optional
 
 from enthusiast_common.connectors import ECommercePlatformConnector

--- a/plugins/enthusiast-source-medusa/enthusiast_source_medusa/medusa_product_source.py
+++ b/plugins/enthusiast-source-medusa/enthusiast_source_medusa/medusa_product_source.py
@@ -1,9 +1,9 @@
+import json
 from typing import Any, Optional
 
 from enthusiast_common import ProductDetails, ProductSourcePlugin
 from enthusiast_common.utils import RequiredFieldsModel
 from pydantic import Field
-import json
 
 from .medusa_api_client import MedusaAPIClient
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,4 @@
 [tool.ruff]
-required-version = "0.15.9"
 line-length = 120
 target-version = "py312"
 [tool.ruff.lint]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,5 @@
 [tool.ruff]
+required-version = "0.15.9"
 line-length = 120
 target-version = "py312"
 [tool.ruff.lint]

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -31,3 +31,6 @@ dependencies = [
 
 [tool.poetry]
 package-mode = false
+
+[tool.poetry.group.dev.dependencies]
+ruff = "0.15.9"


### PR DESCRIPTION
Updated the GitHub Lint pipeline to iterate through the `/plugins/*` folders and run ruff check inside them as well.

Pipeline tested on success and failure cases on the plugin ruff checks.

Adjustments on the plugin code generated automatically via `ruff check --fix`