### PR TITLE
feat: add agentic execution for product web scraper agent

### DIFF
--- a/plugins/enthusiast-agent-product-web-scraper/README.md
+++ b/plugins/enthusiast-agent-product-web-scraper/README.md
@@ -16,3 +16,11 @@ AVAILABLE_AGENTS = [
     'enthusiast_agent_product_web_scraper.ProductWebScraperAgent',
 ]
 ```
+
+To also register the agentic execution definition, add the following to your config/settings_override.py:
+
+```python
+AVAILABLE_AGENTIC_EXECUTION_DEFINITIONS = [
+    'enthusiast_agent_product_web_scraper.ProductWebScraperExecutionDefinition',
+]
+```

--- a/plugins/enthusiast-agent-product-web-scraper/src/enthusiast_agent_product_web_scraper/__init__.py
+++ b/plugins/enthusiast-agent-product-web-scraper/src/enthusiast_agent_product_web_scraper/__init__.py
@@ -1,4 +1,5 @@
 from .agent import ProductWebScraperAgent
 from .config import ProductWebScraperConfigProvider
+from .execution_definition import ProductWebScraperExecutionDefinition
 
-__all__ = ["ProductWebScraperAgent", "ProductWebScraperConfigProvider"]
+__all__ = ["ProductWebScraperAgent", "ProductWebScraperConfigProvider", "ProductWebScraperExecutionDefinition"]

--- a/plugins/enthusiast-agent-product-web-scraper/src/enthusiast_agent_product_web_scraper/config.py
+++ b/plugins/enthusiast-agent-product-web-scraper/src/enthusiast_agent_product_web_scraper/config.py
@@ -2,6 +2,7 @@ from enthusiast_common.agents import BaseAgentConfigProvider, ConfigType
 from enthusiast_common.config import AgentConfigWithDefaults
 
 from .agent import ProductWebScraperAgent
+from .execution_prompt import PRODUCT_WEB_SCRAPER_EXECUTION_PROMPT
 from .prompt import PRODUCT_WEB_SCRAPER_CONVERSATION_PROMPT
 
 
@@ -13,8 +14,13 @@ class ProductWebScraperConfigProvider(BaseAgentConfigProvider):
 
 
     def get_config(self, config_type: ConfigType = ConfigType.CONVERSATION) -> AgentConfigWithDefaults:
+        system_prompt = (
+            PRODUCT_WEB_SCRAPER_CONVERSATION_PROMPT
+            if config_type == ConfigType.CONVERSATION
+            else PRODUCT_WEB_SCRAPER_EXECUTION_PROMPT
+        )
         return AgentConfigWithDefaults(
-            system_prompt=PRODUCT_WEB_SCRAPER_CONVERSATION_PROMPT,
+            system_prompt=system_prompt,
             agent_class=ProductWebScraperAgent,
             tools=ProductWebScraperAgent.TOOLS,
         )

--- a/plugins/enthusiast-agent-product-web-scraper/src/enthusiast_agent_product_web_scraper/execution_definition.py
+++ b/plugins/enthusiast-agent-product-web-scraper/src/enthusiast_agent_product_web_scraper/execution_definition.py
@@ -1,5 +1,3 @@
-from typing import List, Optional
-
 from enthusiast_common.agentic_execution import (
     BaseAgenticExecutionDefinition,
     ExecutionConversationInterface,
@@ -10,8 +8,8 @@ from enthusiast_common.agentic_execution import (
 class ProductWebScraperExecutionInput(ExecutionInputType):
     """Input for the product web scraper agentic execution."""
 
-    urls: List[str]
-    additional_instructions: Optional[str] = None
+    urls: list[str]
+    additional_instructions: str | None = None
 
 
 class ProductWebScraperExecutionDefinition(BaseAgenticExecutionDefinition):

--- a/plugins/enthusiast-agent-product-web-scraper/src/enthusiast_agent_product_web_scraper/execution_definition.py
+++ b/plugins/enthusiast-agent-product-web-scraper/src/enthusiast_agent_product_web_scraper/execution_definition.py
@@ -1,0 +1,37 @@
+from typing import List, Optional
+
+from enthusiast_common.agentic_execution import (
+    BaseAgenticExecutionDefinition,
+    ExecutionConversationInterface,
+    ExecutionInputType,
+)
+
+
+class ProductWebScraperExecutionInput(ExecutionInputType):
+    """Input for the product web scraper agentic execution."""
+
+    urls: List[str]
+    additional_instructions: Optional[str] = None
+
+
+class ProductWebScraperExecutionDefinition(BaseAgenticExecutionDefinition):
+    """Agentic execution definition for the product web scraper agent.
+
+    Scrapes product data from the provided URLs and upserts it into the catalog.
+    """
+
+    EXECUTION_KEY = "product-web-scraper"
+    AGENT_KEY = "enthusiast-agent-product-web-scraper"
+    NAME = "Product Web Scraper"
+    INPUT_TYPE = ProductWebScraperExecutionInput
+
+    def execute(
+        self,
+        input_data: ProductWebScraperExecutionInput,
+        conversation: ExecutionConversationInterface,
+    ) -> str:
+        urls_list = "\n".join(f"- {url}" for url in input_data.urls)
+        message = f"Scrape and upsert the following product pages:\n{urls_list}"
+        if input_data.additional_instructions:
+            message += f"\n\n{input_data.additional_instructions}"
+        return conversation.ask(message)

--- a/plugins/enthusiast-agent-product-web-scraper/src/enthusiast_agent_product_web_scraper/execution_prompt.py
+++ b/plugins/enthusiast-agent-product-web-scraper/src/enthusiast_agent_product_web_scraper/execution_prompt.py
@@ -1,0 +1,46 @@
+PRODUCT_WEB_SCRAPER_EXECUTION_PROMPT = """
+You are an autonomous product web scraper agent running as part of a batch execution pipeline.
+This is not a conversation — there is no human on the other end. Do not use conversational language,
+greetings, explanations, or apologies. Respond only with the required JSON output.
+
+Your task is to scrape each provided URL and upsert the extracted product data into the catalog
+using the product upsert tool.
+
+WORKFLOW:
+1. For each URL, call the scrape_product tool with an action instructing the LLM to extract all
+   fields from the schema below. Always include: return price as a plain decimal number with dot
+   separator and no currency symbols.
+2. After scraping all URLs, upsert all products in a SINGLE BATCH call using the upsert tool.
+3. Do NOT ask for confirmation before upserting — proceed immediately.
+
+DATA FORMAT (field schema reference):
+{data_format}
+IMPORTANT: The above is a FIELD SCHEMA REFERENCE — it defines which fields exist and their
+expected types/shape. It is NOT actual product data. Do NOT use any values from the schema as
+product attributes. Extract ALL products found on the provided pages, regardless of category or
+type. Extract all real product values exclusively from the fetched page content.
+
+DATA FORMAT RULES:
+- Extract, infer, and upsert ONLY the fields defined in the schema above.
+- Do NOT add, rename, or hallucinate fields or values.
+- Leave missing values empty unless directly supported by the fetched content.
+
+EXTRACTION RULES:
+- Verify all values against the fetched page content.
+- Never guess or fabricate information.
+- If multiple variants exist on a page, handle all of them strictly per the schema.
+
+UPSERT TOOL RULES:
+- ALWAYS upsert products in a SINGLE BATCH call when multiple products are ready.
+- Do NOT call the upsert tool separately for individual products.
+- Pass ONLY fields defined in the schema above.
+- Do NOT return JSON, text, or simulated responses instead of calling the tool.
+- The upsert tool will explicitly report success or failure for each product in the batch.
+
+If the upsert tool explicitly reports that no eCommerce connector is configured, return the
+extracted product data as JSON in the shape defined by the schema above.
+
+OUTPUT RULES:
+- Return ONLY a valid JSON object. No prose, no explanation.
+- Format: {{"<url>": "<upsert success or failure reason>", ...}}
+"""


### PR DESCRIPTION
**Blocked by [#368](https://github.com/upsidelab/enthusiast/pull/368)**

Resolves [ENT-268](https://linear.app/enthusiast/issue/ENT-268/add-agentic-execution-for-product-web-scraper-agent) 

  ## Changes                                                                                                                                                                                                                        
                                                                                                                                                                                                                                    
  - `execution_definition.py` — `ProductWebScraperExecutionDefinition` with `EXECUTION_KEY = "product-web-scraper"` and `ProductWebScraperExecutionInput` accepting a list of URLs and optional additional instructions
  - `execution_prompt.py` — dedicated system prompt for autonomous mode: no confirmation step, scrape all URLs, upsert in a single batch, return JSON keyed by URL with upsert result per product                                   
  - `config.py` — `ProductWebScraperConfigProvider` now branches on `ConfigType`: conversation prompt for interactive use, execution prompt for batch mode                                                                          
  - `__init__.py` — exports `ProductWebScraperExecutionDefinition` and `ProductWebScraperExecutionInput`                                                                                                                            
  - `README.md` — documents agentic execution registration    