### PR TITLE
feat: parallelize url scraping in product web scraper agent

### DIFF
--- a/plugins/enthusiast-agent-product-web-scraper/src/enthusiast_agent_product_web_scraper/agent.py
+++ b/plugins/enthusiast-agent-product-web-scraper/src/enthusiast_agent_product_web_scraper/agent.py
@@ -1,9 +1,8 @@
+from enthusiast_agent_catalog_enrichment.tools import UpsertProductDetailsTool
 from enthusiast_agent_tool_calling import BaseToolCallingAgent
 from enthusiast_common.config.base import LLMToolConfig
 from enthusiast_common.utils import RequiredFieldsModel
 from pydantic import Field, Json
-
-from enthusiast_agent_catalog_enrichment.tools import UpsertProductDetailsTool
 
 from .tools.scrape_product_tool import ScrapeProductTool
 

--- a/plugins/enthusiast-agent-product-web-scraper/src/enthusiast_agent_product_web_scraper/execution_prompt.py
+++ b/plugins/enthusiast-agent-product-web-scraper/src/enthusiast_agent_product_web_scraper/execution_prompt.py
@@ -7,9 +7,9 @@ Your task is to scrape each provided URL and upsert the extracted product data i
 using the product upsert tool.
 
 WORKFLOW:
-1. For each URL, call the scrape_product tool with an action instructing the LLM to extract all
-   fields from the schema below. Always include: return price as a plain decimal number with dot
-   separator and no currency symbols.
+1. Call the scrape_product_data tool ONCE with all provided URLs. In the `action` field, instruct
+   the LLM to extract all fields from the schema below. Always include: return price as a plain
+   decimal number with dot separator and no currency symbols.
 2. After scraping all URLs, upsert all products in a SINGLE BATCH call using the upsert tool.
 3. Do NOT ask for confirmation before upserting — proceed immediately.
 

--- a/plugins/enthusiast-agent-product-web-scraper/src/enthusiast_agent_product_web_scraper/prompt.py
+++ b/plugins/enthusiast-agent-product-web-scraper/src/enthusiast_agent_product_web_scraper/prompt.py
@@ -5,13 +5,14 @@ upserting the extracted data into the configured ecommerce platform.
 Your PRIMARY goal is to upsert products into the catalog using the product upsert tool.
 
 WORKFLOW:
-1. For each URL the user provides, call the fetch_and_extract_product_data tool.
-   In the `action` field, instruct the LLM to extract the exact fields from the schema below.
-   Include any relevant context from the conversation (e.g. if the user mentioned where a field
-   can be found on the page, pass that hint in the action).
+1. Call the scrape_product_data tool ONCE with all URLs the user provides. In the `action` field,
+   instruct the LLM to extract the exact fields from the schema below. Include any relevant context
+   from the conversation (e.g. if the user mentioned where a field can be found on the page, pass
+   that hint in the action).
    Always include: return price as a plain decimal number with dot separator and no currency symbols.
-2. If the tool returns a JavaScript rendering warning, relay it clearly to the user and ask them
-   to verify the URL or provide an alternative source (e.g. a direct product data page).
+2. If the tool result contains a JavaScript rendering warning for any URL, relay it clearly to the
+   user and ask them to verify that URL or provide an alternative source (e.g. a direct product
+   data page).
 3. If the user provides multiple URLs that appear to describe the same product (matching SKU,
    name, or other identifiers), compare the extracted values across sources and reconcile any
    discrepancies before upserting. Prefer values that appear consistently across more sources.

--- a/plugins/enthusiast-agent-product-web-scraper/src/enthusiast_agent_product_web_scraper/tools/scrape_product_tool.py
+++ b/plugins/enthusiast-agent-product-web-scraper/src/enthusiast_agent_product_web_scraper/tools/scrape_product_tool.py
@@ -1,4 +1,6 @@
+import json
 import logging
+from concurrent.futures import ThreadPoolExecutor, as_completed
 
 from bs4 import BeautifulSoup
 from curl_cffi import requests as curl_requests
@@ -12,15 +14,16 @@ logger = logging.getLogger(__name__)
 
 _MINIMAL_CONTENT_THRESHOLD = 300
 _CHROME_IMPERSONATION = "chrome124"
+_MAX_WORKERS = 5
 
 
 class ScrapeProductInput(BaseModel):
     """Input schema for ScrapeProductTool."""
 
-    url: str = Field(description="URL of the product web page to fetch and extract data from")
+    urls: list[str] = Field(description="List of product web page URLs to fetch and extract data from")
     action: str = Field(
         description=(
-            "Describe what data to extract from the page and any additional context "
+            "Describe what data to extract from the pages and any additional context "
             "(e.g. which fields to look for, hints about where data is located on the page, "
             "or format requirements such as returning price as a plain decimal number)."
         )
@@ -38,27 +41,45 @@ class ScrapeProductConfig(RequiredFieldsModel):
 
 
 class ScrapeProductTool(BaseLLMTool):
-    """Fetches a product web page and extracts structured product data from it using an LLM.
+    """Fetches product web pages and extracts structured product data from them using an LLM.
 
     Uses curl_cffi to impersonate a Chrome browser at the TLS level, bypassing basic
-    bot-detection systems. BeautifulSoup strips HTML to plain text which is then passed
-    to an LLM sub-call for field extraction. JavaScript-rendered pages (SPAs) may still
-    return minimal content — in that case the tool returns a warning so the agent can
-    relay it to the user.
+    bot-detection systems. Multiple URLs are fetched in parallel using a thread pool.
+    BeautifulSoup strips HTML to plain text which is then passed to an LLM sub-call for
+    field extraction. JavaScript-rendered pages (SPAs) may still return minimal content —
+    in that case the tool returns a warning for that URL.
     """
 
     NAME = "scrape_product_data"
     DESCRIPTION = (
-        "Fetches a product web page from the given URL and extracts product data from its content. "
-        "Provide the URL and a description of what data to extract and any format requirements. "
-        "Uses Chrome TLS impersonation to bypass basic bot detection."
+        "Fetches one or more product web pages and extracts product data from their content. "
+        "Provide a list of URLs and a description of what data to extract and any format requirements. "
+        "URLs are fetched in parallel. Uses Chrome TLS impersonation to bypass basic bot detection."
     )
     ARGS_SCHEMA = ScrapeProductInput
     RETURN_DIRECT = False
     CONFIGURATION_ARGS = ScrapeProductConfig
 
-    def run(self, url: str, action: str) -> str:
-        """Fetch the page at `url` and extract the requested fields via LLM.
+    def run(self, urls: list[str], action: str) -> str:
+        """Fetch each URL in parallel and extract the requested fields via LLM.
+
+        Args:
+            urls: Product page URLs to scrape.
+            action: Free-form extraction instruction passed as context to the LLM sub-call.
+
+        Returns:
+            JSON object mapping each URL to its extracted data or error message.
+        """
+        with ThreadPoolExecutor(max_workers=_MAX_WORKERS) as executor:
+            futures = {executor.submit(self._scrape_url, url, action): url for url in urls}
+            results = {}
+            for future in as_completed(futures):
+                url = futures[future]
+                results[url] = future.result()
+        return json.dumps(results, ensure_ascii=False)
+
+    def _scrape_url(self, url: str, action: str) -> str:
+        """Fetch a single URL and extract product data from it.
 
         Args:
             url: The product page URL to scrape.

--- a/plugins/enthusiast-common/enthusiast_common/agentic_execution/__init__.py
+++ b/plugins/enthusiast-common/enthusiast_common/agentic_execution/__init__.py
@@ -3,7 +3,13 @@ from .errors import ExecutionFailureCode
 from .input import ExecutionInputType
 from .result import ExecutionResult
 from .status import ExecutionStatus
-from .validators import BaseExecutionValidator, IsValidJsonValidator, ValidatorFailureResponse, ValidatorResponse, ValidatorSuccessResponse
+from .validators import (
+    BaseExecutionValidator,
+    IsValidJsonValidator,
+    ValidatorFailureResponse,
+    ValidatorResponse,
+    ValidatorSuccessResponse,
+)
 
 __all__ = [
     "BaseAgenticExecutionDefinition",

--- a/plugins/enthusiast-common/enthusiast_common/agentic_execution/validators/__init__.py
+++ b/plugins/enthusiast-common/enthusiast_common/agentic_execution/validators/__init__.py
@@ -1,6 +1,6 @@
 from .base import BaseExecutionValidator
-from .is_valid_json_validator import IsValidJsonValidator
 from .failure_response import ValidatorFailureResponse
+from .is_valid_json_validator import IsValidJsonValidator
 from .response import ValidatorResponse
 from .success_response import ValidatorSuccessResponse
 

--- a/server/utils/tests/test_functions.py
+++ b/server/utils/tests/test_functions.py
@@ -4,7 +4,6 @@ from typing import Dict, List
 
 import pytest
 from pydantic import BaseModel, Field
-
 from utils.functions import extract_type_info, get_model_descriptor_from_class_field, import_from_string
 
 


### PR DESCRIPTION
Resolves [ENT-276](https://linear.app/enthusiast/issue/ENT-276/parallelize-url-scraping-in-product-web-scraper-agent)

  ### What changed                                                                                                                                                                                                                  
                                                                                                                                                                                                                                    
  Previously `scrape_product_data` accepted a single `url: str` and the agent called it N times sequentially for N URLs.                                                                                                            
                                                            
  This PR parallelizes scraping:

  - **Tool input** changed from `url: str` to `urls: list[str]`                                                                                                                                                                     
  - URLs are fetched **concurrently** via `ThreadPoolExecutor` (max 5 workers)
  - Tool now returns a **JSON object** mapping each URL to its extracted data or error message                                                                                                                                      
  - **Conversation prompt** updated to instruct the agent to call the tool once with all URLs    