### PR TITLE
feat: add documentation for Catalog Web Import and Invoice Scanning agents

### DIFF
--- a/docs/app/agents/_meta.ts
+++ b/docs/app/agents/_meta.ts
@@ -6,5 +6,11 @@ export default {
   },
   "order-intake": {
     title: "Order Intake"
+  },
+  "catalog-web-import": {
+    title: "Catalog Web Import"
+  },
+  "invoice-scanning": {
+    title: "Invoice Scanning"
   }
 }

--- a/docs/app/agents/page.tsx
+++ b/docs/app/agents/page.tsx
@@ -28,6 +28,8 @@ export default async function Page() {
         <AgentCard name="Catalog Enrichment" imageSrc="/tools/enthusiast/img/agents/catalog-enrichment.png" href="/agents/catalog-enrichment" />
         <AgentCard name="Order Intake" imageSrc="/tools/enthusiast/img/agents/order-intake.png" href="/agents/order-intake" />
         <AgentCard name="User Manual Search" imageSrc="/tools/enthusiast/img/agents/user-manual-search.png" href="/agents/user-manual-search" />
+        <AgentCard name="Catalog Web Import" href="/agents/catalog-web-import" />
+        <AgentCard name="Invoice Scanning" href="/agents/invoice-scanning" />
       </Cards>
       <H2>Build a Custom Agent</H2>
       <P>These pre-built agents are just a starting point. Enthusiast lets you build custom agents from the ground up, tailored to your specific workflows.</P>

--- a/docs/content/agents/catalog-web-import.mdx
+++ b/docs/content/agents/catalog-web-import.mdx
@@ -24,5 +24,4 @@ export const useCases = [
   registerAgentModule="enthusiast_agent_catalog_web_import"
   agentDescription={description}
   agentUseCases={useCases}
-  videoUrl="https://content.upsidelab.io/enthusiast/catalog-web-import.mp4"
 />

--- a/docs/content/agents/catalog-web-import.mdx
+++ b/docs/content/agents/catalog-web-import.mdx
@@ -1,0 +1,28 @@
+import Agent from "@/components/agent";
+
+export const description = "The Catalog Web Import agent accepts one or more product page URLs and extracts structured product data directly from those pages. It uses browser-level TLS impersonation to fetch pages reliably, passes the content through an LLM to pull out the fields defined in your schema, and upserts all products in a single batch. When confirmation mode is enabled, it presents the extracted data for review before writing anything to the catalog.";
+
+export const useCases = [
+  {
+    title: "Supplier Website Onboarding",
+    description: "When a supplier shares their product catalog as a website rather than a document, the agent can scrape and import all relevant product pages directly, eliminating manual copy-paste."
+  },
+  {
+    title: "Catalog Expansion from Distributor Pages",
+    description: "Sales teams can drop in a list of distributor or manufacturer product URLs and have all products extracted and added to the catalog in one go, without leaving the chat interface."
+  },
+  {
+    title: "Bulk Multi-URL Import",
+    description: "Provide dozens of product page URLs in a single request and the agent fetches them in parallel, reconciles any overlapping data, and upserts everything in one batch call."
+  },
+];
+
+<Agent
+  name="Catalog Web Import"
+  agentClassName="CatalogWebImportAgent"
+  pipName="enthusiast-agent-catalog-web-import"
+  registerAgentModule="enthusiast_agent_catalog_web_import"
+  agentDescription={description}
+  agentUseCases={useCases}
+  videoUrl="https://content.upsidelab.io/enthusiast/catalog-web-import.mp4"
+/>

--- a/docs/content/agents/invoice-scanning.mdx
+++ b/docs/content/agents/invoice-scanning.mdx
@@ -1,0 +1,28 @@
+import Agent from "@/components/agent";
+
+export const description = "The Invoice Scanning agent processes supplier invoices - PDFs, scanned images, or structured files - to extract line item SKUs and quantities, then updates stock levels in your e-commerce platform in a single batch. When confirmation mode is enabled, it presents the extracted items for review before making any changes, and clearly reports which SKUs were updated and which could not be found in the catalog.";
+
+export const useCases = [
+  {
+    title: "Incoming Delivery Processing",
+    description: "When goods arrive from a supplier, upload the delivery note or invoice and the agent automatically increases stock levels for every line item, eliminating manual warehouse data entry."
+  },
+  {
+    title: "Paper Invoice Digitization",
+    description: "Scanned paper invoices from suppliers can be uploaded directly; the agent reads the line items and translates them into stock updates without any manual transcription."
+  },
+  {
+    title: "Goods Receipt Verification",
+    description: "Before committing stock updates, the confirmation step lets warehouse staff review the extracted line items and catch discrepancies between the invoice and the actual delivery."
+  },
+];
+
+<Agent
+  name="Invoice Scanning"
+  agentClassName="InvoiceScanningAgent"
+  pipName="enthusiast-agent-invoice-scanning"
+  registerAgentModule="enthusiast_agent_invoice_scanning"
+  agentDescription={description}
+  agentUseCases={useCases}
+  videoUrl="https://content.upsidelab.io/enthusiast/invoice-scanning.mp4"
+/>

--- a/docs/content/agents/invoice-scanning.mdx
+++ b/docs/content/agents/invoice-scanning.mdx
@@ -24,5 +24,4 @@ export const useCases = [
   registerAgentModule="enthusiast_agent_invoice_scanning"
   agentDescription={description}
   agentUseCases={useCases}
-  videoUrl="https://content.upsidelab.io/enthusiast/invoice-scanning.mp4"
 />

--- a/docs/content/docs/index.mdx
+++ b/docs/content/docs/index.mdx
@@ -17,6 +17,10 @@ Enthusiast is your open-source AI agent for e-commerce. Connect it to your produ
 
 - [Product Catalog Enrichment](https://upsidelab.io/tools/enthusiast/agents/catalog-enrichment) Extract product descriptions, attributes, or translations from unstructured product sheets.
 
+- [Catalog Web Import](https://upsidelab.io/tools/enthusiast/agents/catalog-web-import) Import product data directly from supplier or distributor web pages by providing URLs.
+
+- [Invoice Scanning](https://upsidelab.io/tools/enthusiast/agents/invoice-scanning) Process supplier invoices to extract line items and automatically update stock levels in your e-commerce platform.
+
 ## Main Features
 
 - Pre-built integrations with popular e-commerce platforms


### PR DESCRIPTION
 Add documentation for Catalog Web Import and Invoice Scanning agents
                                                                                                                                                                                                                                    
  Adds documentation pages for two new pre-built agents, consistent in structure and style with the existing agent docs (Product Search, Order Intake, Catalog Enrichment, User Manual Search).
                                                                                                                                                                                                                                    
  Changes:
  - docs/content/agents/catalog-web-import.mdx — new doc page for the Catalog Web Import agent                                                                                                                                      
  - docs/content/agents/invoice-scanning.mdx — new doc page for the Invoice Scanning agent    
  - docs/app/agents/page.tsx — added both agents to the pre-built agents listing page     
  - docs/app/agents/_meta.ts — registered new routes in navigation                                                                                                                                                                  
  - docs/content/docs/index.mdx — added both agents to the Example Use Cases section                                                                                                                                                
                                                                                                                                                                                                                                    
  Both pages include video placeholders (videoUrl prop) following the same pattern as other agents — videos can be added by uploading the files to the CDN without any code changes. Agent images (catalog-web-import.png,          
  invoice-scanning.png) can be added to public/img/agents/ to complete the card thumbnails on the listing page.    