### PR TITLE
fix: correct data set response handling and disable pagination in DataSetListView

### DIFF
--- a/frontend/src/components/navigation/data-set-selector.tsx
+++ b/frontend/src/components/navigation/data-set-selector.tsx
@@ -59,6 +59,7 @@ export function DataSetSelector() {
         <DropdownMenuLabel className="text-xs text-muted-foreground">
           Data Sets
         </DropdownMenuLabel>
+        <div className="max-h-64 overflow-y-auto">
         {dataSets.length === 0 ? (
           <DropdownMenuItem disabled className="text-muted-foreground">
             No data sets available
@@ -76,6 +77,7 @@ export function DataSetSelector() {
             </DropdownMenuItem>
           ))
         )}
+        </div>
         {account && account.isStaff &&
           <>
             <Separator className="my-2"/>

--- a/frontend/src/lib/api/data-sets.ts
+++ b/frontend/src/lib/api/data-sets.ts
@@ -53,8 +53,8 @@ export class DataSetsApiClient extends BaseApiClient {
     let url: string | null = `${this.apiBase}/api/data_sets`;
 
     while (url) {
-      const response = await fetch(url, this._requestConfiguration());
-      const data = await response.json();
+      const response: Response = await fetch(url, this._requestConfiguration());
+      const data: { results: DataSet[]; next: string | null } = await response.json();
       results.push(...data.results);
       url = data.next;
     }

--- a/frontend/src/lib/api/data-sets.ts
+++ b/frontend/src/lib/api/data-sets.ts
@@ -49,8 +49,17 @@ export type ECommerceIntegrationResponse = {
 
 export class DataSetsApiClient extends BaseApiClient {
   async getDataSets(): Promise<DataSet[]> {
-    const response = await fetch(`${this.apiBase}/api/data_sets`, this._requestConfiguration());
-    return await response.json() as DataSet[];
+    const results: DataSet[] = [];
+    let url: string | null = `${this.apiBase}/api/data_sets`;
+
+    while (url) {
+      const response = await fetch(url, this._requestConfiguration());
+      const data = await response.json();
+      results.push(...data.results);
+      url = data.next;
+    }
+
+    return results;
   }
 
   async createDataSet(dataSet: DataSet, preconfigureAgents: boolean): Promise<number> {

--- a/frontend/src/lib/api/data-sets.ts
+++ b/frontend/src/lib/api/data-sets.ts
@@ -50,7 +50,7 @@ export type ECommerceIntegrationResponse = {
 export class DataSetsApiClient extends BaseApiClient {
   async getDataSets(): Promise<DataSet[]> {
     const response = await fetch(`${this.apiBase}/api/data_sets`, this._requestConfiguration());
-    return (await response.json()).results as DataSet[];
+    return await response.json() as DataSet[];
   }
 
   async createDataSet(dataSet: DataSet, preconfigureAgents: boolean): Promise<number> {

--- a/server/catalog/views.py
+++ b/server/catalog/views.py
@@ -54,7 +54,6 @@ class SyncAllSourcesView(APIView):
 
 class DataSetListView(ListCreateAPIView):
     permission_classes = [IsAuthenticated]
-    pagination_class = None
 
     def get_serializer_class(self):
         if self.request.method == "POST":

--- a/server/catalog/views.py
+++ b/server/catalog/views.py
@@ -54,6 +54,7 @@ class SyncAllSourcesView(APIView):
 
 class DataSetListView(ListCreateAPIView):
     permission_classes = [IsAuthenticated]
+    pagination_class = None
 
     def get_serializer_class(self):
         if self.request.method == "POST":


### PR DESCRIPTION
Bug: Broken dataset display when more than 25 datasets exist                                                                                                                  
                                                            
  Root cause

  DRF's global DEFAULT_PAGINATION_CLASS (PageNumberPagination, PAGE_SIZE: 25) was applied to the DataSetListView endpoint (GET /api/data_sets). The frontend's getDataSets()
  called this endpoint and read only .results from the first page — so any dataset beyond the 25th was silently invisible in the sidebar selector and the dataset list.

  Fix

  - Frontend (src/lib/api/data-sets.ts): Updated getDataSets() to paginate through all pages by following the next link until it's null, collecting results from each page. The
  backend API remains unchanged to preserve backward compatibility.
  - UI (components/navigation/data-set-selector.tsx): Added a scrollable container (max-h-64 overflow-y-auto) to the dataset dropdown so all datasets are accessible regardless
  of count, while the "New" and "Manage" actions remain pinned below the scroll area.
  
  
  Video:
 
https://github.com/user-attachments/assets/6ed66964-6565-4069-b125-316e16f5d554

