### PR TITLE
feat: fix non streaming models displaying error as normal message bubble

### DIFF
--- a/frontend/src/components/conversation-view/chat-session.tsx
+++ b/frontend/src/components/conversation-view/chat-session.tsx
@@ -235,7 +235,7 @@ export function ChatSession({ pendingMessage }: ChatSessionProps) {
         setIsAgentLoading(false);
         setMessages((prev) => [
           ...prev,
-          { type: "ai", text: response.text, id: response.id }
+          { type: response.type === "system" ? "system" : "ai", text: response.text, id: response.id }
         ]);
         setIsLoading(false);
         scrollToLastMessage();

--- a/server/agent/tests/test_views.py
+++ b/server/agent/tests/test_views.py
@@ -481,6 +481,26 @@ class TestConversationView:
         assert response.data["streaming"] is True
         mock_task.assert_called_once()
 
+    def test_non_streaming_provider_disables_streaming_in_task(self, api_client, url, conversation):
+        payload = {
+            "data_set_id": conversation.data_set.id,
+            "question_message": "Hello?",
+            "streaming": True,
+        }
+        with (
+            patch(
+                "agent.views.respond_to_user_message_task.apply_async",
+                return_value=type("obj", (), {"id": "fake-task-id"}),
+            ) as mock_task,
+            patch("agent.views.LanguageModelRegistry.provider_for_dataset") as mock_provider,
+        ):
+            mock_provider.return_value = type("obj", (), {"STREAMING_AVAILABLE": False})
+            response = api_client.post(url, payload, format="json")
+
+        assert response.status_code == status.HTTP_202_ACCEPTED
+        assert response.data["streaming"] is False
+        assert mock_task.call_args.kwargs["kwargs"]["streaming"] is False
+
     def test_invalid_payload_returns_400(self, api_client, url):
         payload = {"data_set_id": None}
         response = api_client.post(url, payload, format="json")

--- a/server/agent/views.py
+++ b/server/agent/views.py
@@ -132,18 +132,19 @@ class ConversationView(APIView):
         data_set = Conversation.objects.get(id=conversation_id).data_set
         data_set_repo = DjangoDataSetRepository(DataSet)
         language_model_provider_class = LanguageModelRegistry(data_set_repo).provider_for_dataset(data_set.id)
+        effective_streaming = language_model_provider_class.STREAMING_AVAILABLE and streaming
         task = respond_to_user_message_task.apply_async(
             kwargs={
                 "conversation_id": conversation_id,
                 "data_set_id": data_set_id,
                 "user_id": request.user.id,
                 "message": question_message,
-                "streaming": streaming,
+                "streaming": effective_streaming,
             }
         )
 
         return Response(
-            {"task_id": task.id, "streaming": language_model_provider_class.STREAMING_AVAILABLE and streaming},
+            {"task_id": task.id, "streaming": effective_streaming},
             status=status.HTTP_202_ACCEPTED,
         )
 

--- a/server/agent/views.py
+++ b/server/agent/views.py
@@ -128,10 +128,10 @@ class ConversationView(APIView):
 
         data_set_id = serializer.validated_data.get("data_set_id")
         question_message = serializer.validated_data.get("question_message")
-        streaming = language_model_provider_class.STREAMING_AVAILABLE and serializer.validated_data.get("streaming")
         data_set = Conversation.objects.get(id=conversation_id).data_set
         data_set_repo = DjangoDataSetRepository(DataSet)
         language_model_provider_class = LanguageModelRegistry(data_set_repo).provider_for_dataset(data_set.id)
+        streaming = language_model_provider_class.STREAMING_AVAILABLE and serializer.validated_data.get("streaming")
         task = respond_to_user_message_task.apply_async(
             kwargs={
                 "conversation_id": conversation_id,

--- a/server/agent/views.py
+++ b/server/agent/views.py
@@ -128,10 +128,10 @@ class ConversationView(APIView):
 
         data_set_id = serializer.validated_data.get("data_set_id")
         question_message = serializer.validated_data.get("question_message")
+        streaming = language_model_provider_class.STREAMING_AVAILABLE and serializer.validated_data.get("streaming")
         data_set = Conversation.objects.get(id=conversation_id).data_set
         data_set_repo = DjangoDataSetRepository(DataSet)
         language_model_provider_class = LanguageModelRegistry(data_set_repo).provider_for_dataset(data_set.id)
-        streaming = language_model_provider_class.STREAMING_AVAILABLE and serializer.validated_data.get("streaming")
         task = respond_to_user_message_task.apply_async(
             kwargs={
                 "conversation_id": conversation_id,

--- a/server/agent/views.py
+++ b/server/agent/views.py
@@ -128,11 +128,10 @@ class ConversationView(APIView):
 
         data_set_id = serializer.validated_data.get("data_set_id")
         question_message = serializer.validated_data.get("question_message")
-        streaming = serializer.validated_data.get("streaming")
         data_set = Conversation.objects.get(id=conversation_id).data_set
         data_set_repo = DjangoDataSetRepository(DataSet)
         language_model_provider_class = LanguageModelRegistry(data_set_repo).provider_for_dataset(data_set.id)
-        streaming = language_model_provider_class.STREAMING_AVAILABLE and streaming
+        streaming = language_model_provider_class.STREAMING_AVAILABLE and serializer.validated_data.get("streaming")
         task = respond_to_user_message_task.apply_async(
             kwargs={
                 "conversation_id": conversation_id,

--- a/server/agent/views.py
+++ b/server/agent/views.py
@@ -132,19 +132,19 @@ class ConversationView(APIView):
         data_set = Conversation.objects.get(id=conversation_id).data_set
         data_set_repo = DjangoDataSetRepository(DataSet)
         language_model_provider_class = LanguageModelRegistry(data_set_repo).provider_for_dataset(data_set.id)
-        effective_streaming = language_model_provider_class.STREAMING_AVAILABLE and streaming
+        streaming = language_model_provider_class.STREAMING_AVAILABLE and streaming
         task = respond_to_user_message_task.apply_async(
             kwargs={
                 "conversation_id": conversation_id,
                 "data_set_id": data_set_id,
                 "user_id": request.user.id,
                 "message": question_message,
-                "streaming": effective_streaming,
+                "streaming": streaming,
             }
         )
 
         return Response(
-            {"task_id": task.id, "streaming": effective_streaming},
+            {"task_id": task.id, "streaming": streaming},
             status=status.HTTP_202_ACCEPTED,
         )
 


### PR DESCRIPTION
This pull request addresses how streaming is handled for chat responses, ensuring that streaming is only enabled if the selected language model provider supports it. It also updates the chat UI to correctly display system messages, and adds a test to verify streaming is disabled when not supported by the provider.

**Streaming support logic:**

* The `post` method in `server/agent/views.py` now checks if the language model provider supports streaming before enabling it, ensuring the `streaming` flag is only set to `True` if supported. [[1]](diffhunk://#diff-220b6492139b9bab1b34f303e48d805503fc169b573c824afee6ae3e6aeda0ecL131-R131) [[2]](diffhunk://#diff-220b6492139b9bab1b34f303e48d805503fc169b573c824afee6ae3e6aeda0ecL146-R146)

**Frontend message handling:**

* The `ChatSession` component in `chat-session.tsx` now distinguishes between "system" and "ai" message types, allowing system messages to be rendered appropriately in the UI.

**Testing improvements:**

* Added a test in `test_views.py` to verify that if the language model provider does not support streaming, the API disables streaming in both the response and the background task invocation.