### PR TITLE
feat: add option to remove dataset

### DIFF
--- a/frontend/src/components/data-sets/delete-data-set-modal.tsx
+++ b/frontend/src/components/data-sets/delete-data-set-modal.tsx
@@ -1,0 +1,56 @@
+import { useState } from "react";
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { ApiClient } from "@/lib/api";
+import { authenticationProviderInstance } from "@/lib/authentication-provider";
+import { DataSet } from "@/lib/types";
+
+const api = new ApiClient(authenticationProviderInstance);
+
+interface DeleteDataSetModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  dataSet: DataSet;
+  onConfirm: () => void;
+}
+
+export function DeleteDataSetModal({ open, onOpenChange, dataSet, onConfirm }: DeleteDataSetModalProps) {
+  const [deleting, setDeleting] = useState(false);
+
+  const handleDelete = async () => {
+    if (!dataSet.id) return;
+    setDeleting(true);
+    try {
+      await api.dataSets().deleteDataSet(dataSet.id);
+      onConfirm();
+    } catch (error) {
+      console.error("Failed to delete data set:", error);
+      alert("Failed to delete data set. Please try again.");
+    } finally {
+      setDeleting(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>Delete Data Set</DialogTitle>
+        </DialogHeader>
+        <div className="py-4 space-y-2">
+          <p className="text-sm">Are you sure you want to delete <strong>"{dataSet.name}"</strong>?</p>
+          <p className="text-sm text-muted-foreground">
+            This will also permanently delete all products, documents, sources, agents, conversations, and the eCommerce integration associated with this data set.
+          </p>
+          <p className="text-sm text-muted-foreground">This action cannot be undone.</p>
+        </div>
+        <DialogFooter className="flex justify-between">
+          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={deleting}>Cancel</Button>
+          <Button variant="destructive" onClick={handleDelete} disabled={deleting}>
+            {deleting ? "Deleting..." : "Delete"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/data-sets/edit-data-set-form.tsx
+++ b/frontend/src/components/data-sets/edit-data-set-form.tsx
@@ -8,6 +8,8 @@ import { DataSetFormSchema } from "./data-set-form-schema.ts";
 import { useEffect, useState } from "react";
 import { Spinner } from "@/components/util/spinner.tsx";
 import { Alert, AlertDescription } from "@/components/ui/alert.tsx";
+import { Button } from "@/components/ui/button.tsx";
+import { DeleteDataSetModal } from "./delete-data-set-modal.tsx";
 
 const api = new ApiClient(authenticationProviderInstance);
 
@@ -18,6 +20,7 @@ export function EditDataSetForm() {
   const [dataSet, setDataSet] = useState<DataSet | undefined>(undefined);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [deleteModalOpen, setDeleteModalOpen] = useState(false);
 
   // Fetch the actual data set
   useEffect(() => {
@@ -96,11 +99,26 @@ export function EditDataSetForm() {
   }
 
   return (
-    <DataSetForm
-      initialData={dataSet}
-      onSubmit={handleSubmit}
-      submitButtonText="Update"
-      disabledFields={['embeddingProvider', 'embeddingModel', 'embeddingVectorSize']}
-    />
+    <>
+      <DataSetForm
+        initialData={dataSet}
+        onSubmit={handleSubmit}
+        submitButtonText="Update"
+        disabledFields={['embeddingProvider', 'embeddingModel', 'embeddingVectorSize']}
+      />
+      <div className="mt-8 border-t pt-6">
+        <Button variant="destructive" onClick={() => setDeleteModalOpen(true)}>Delete Data Set</Button>
+      </div>
+      <DeleteDataSetModal
+        open={deleteModalOpen}
+        onOpenChange={setDeleteModalOpen}
+        dataSet={dataSet}
+        onConfirm={async () => {
+          const updatedDataSets = await api.dataSets().getDataSets();
+          setDataSets(updatedDataSets);
+          navigate('/data-sets');
+        }}
+      />
+    </>
   );
 } 

--- a/frontend/src/components/data-sets/edit-data-set-form.tsx
+++ b/frontend/src/components/data-sets/edit-data-set-form.tsx
@@ -107,6 +107,7 @@ export function EditDataSetForm() {
         disabledFields={['embeddingProvider', 'embeddingModel', 'embeddingVectorSize']}
       />
       <div className="mt-8 border-t pt-6">
+        <h3 className="text-sm font-semibold text-destructive mb-4">Danger Zone</h3>
         <Button variant="destructive" onClick={() => setDeleteModalOpen(true)}>Delete Data Set</Button>
       </div>
       <DeleteDataSetModal

--- a/frontend/src/lib/api/data-sets.ts
+++ b/frontend/src/lib/api/data-sets.ts
@@ -300,6 +300,20 @@ export class DataSetsApiClient extends BaseApiClient {
     } as DataSet;
   }
 
+  async deleteDataSet(dataSetId: number): Promise<void> {
+    const response = await fetch(
+      `${this.apiBase}/api/data_sets/${dataSetId}`,
+      {
+        ...this._requestConfiguration(),
+        method: "DELETE",
+      }
+    );
+
+    if (!response.ok) {
+      throw new Error("Failed to delete data set");
+    }
+  }
+
   async updateDataSet(dataSetId: number, dataSet: DataSet): Promise<void> {
     const body: UpdateDataSetPayload = {
       id: dataSet.id,

--- a/server/catalog/views.py
+++ b/server/catalog/views.py
@@ -13,6 +13,8 @@ from account.models import User
 from account.serializers import UserSerializer
 from agent.core.registries.embeddings import EmbeddingProviderRegistry
 from agent.core.registries.language_models import LanguageModelRegistry
+from agent.models import AgenticExecution, Message
+from agent.models.conversation import ConversationFile
 from agent.services import AgentPreconfigurationService
 from sync.tasks import (
     sync_all_document_sources,
@@ -127,6 +129,30 @@ class DataSetDetailView(RetrieveAPIView):
         serializer.save()
 
         return Response(serializer.data, status=status.HTTP_200_OK)
+
+    @swagger_auto_schema(
+        operation_description="Delete a data set",
+        manual_parameters=[
+            openapi.Parameter(
+                "data_set_id", openapi.IN_PATH, description="ID of the data set", type=openapi.TYPE_INTEGER
+            )
+        ],
+    )
+    def delete(self, request, *args, **kwargs):
+        instance = self.get_object()
+
+        with transaction.atomic():
+            Message.objects.filter(conversation__data_set=instance).delete()
+            ConversationFile.objects.filter(conversation__data_set=instance).delete()
+            AgenticExecution.objects.filter(conversation__data_set=instance).delete()
+            instance.conversation_set.all().delete()
+            instance.products.all().delete()
+            instance.documents.all().delete()
+            instance.product_sources.all().delete()
+            instance.document_sources.all().delete()
+            instance.delete()
+
+        return Response(status=status.HTTP_204_NO_CONTENT)
 
 
 class DataSetUserListView(ListCreateAPIView):


### PR DESCRIPTION
## Summary
  
  Adds the ability to delete a data set via the UI and API.

  - New **Delete Data Set** button in the bottom zone section of the edit page
  - Confirmation dialog listing what will be permanently deleted
  - `DELETE /api/data_sets/{id}` endpoint (admin only)

  ## What gets deleted

  Deleting a data set permanently removes all associated data in a single transaction:

  - Products and documents (including vector chunks)
  - Product sources and document sources
  - Agents
  - Conversations (including messages and files)
  - Agentic executions
  - eCommerce integration

  ## Changes
  
  - **`server/catalog/views.py`** — `delete()` method on `DataSetDetailView`, cascades all related objects in correct FK order before deleting the data set
  - **`frontend/src/components/data-sets/delete-data-set-modal.tsx`** — confirmation dialog with destructive action warning
  - **`frontend/src/components/data-sets/edit-data-set-form.tsx`** — danger zone section with delete button, refreshes context and redirects to `/data-sets` on success
  - **`frontend/src/lib/api/data-sets.ts`** — `deleteDataSet()` method
  
 ## Demo

https://github.com/user-attachments/assets/2acabada-19ef-4922-b2a4-1a428bb6b7f2


  