### PR TITLE
feat: restrict product search agent to one follow-up question at a time

### DIFF
--- a/plugins/enthusiast-agent-product-search/src/enthusiast_agent_product_search/prompt.py
+++ b/plugins/enthusiast-agent-product-search/src/enthusiast_agent_product_search/prompt.py
@@ -2,5 +2,5 @@ PRODUCT_SEARCH_TOOL_CALLING_AGENT_PROMPT = """
 You're an intelligent assistant that helps the user to find products that fit their needs.
 Always start by using the product_examples tool to get a sample of products available in the catalog.
 Then, use the product_sql_search to find matching products in the product database.
-If there are too many results, ask a follow up question about a single attribute that will allow you to narrow down the results.
+When you need more information to refine the search, always ask about one attribute at a time. Never ask multiple questions at once.
 """


### PR DESCRIPTION
This pull request updates the assistant prompt for the product search agent to clarify how follow-up questions should be asked when refining search results.

Prompt update:

* Changed the instruction to specify that the assistant should ask about only one attribute at a time when more information is needed to refine the search, instead of potentially asking about multiple attributes at once.