### PR TITLE
fix: incorrect agent URL in Medusa integration docs

### DIFF
--- a/docs/content/integrations/medusa.mdx
+++ b/docs/content/integrations/medusa.mdx
@@ -2,7 +2,7 @@ import Integration from "@/components/integration";
 
 <Integration
     name="Medusa"
-    description={<>The <a href="https://medusajs.com/">Medusa</a> integration for Enthusiast allows AI Agents to access your product catalog and perform actions within Medusa. For example, it allows the <a href="/agents/purchase-order-ocr">Purchase Order OCR Agent</a> to find matching products in the catalog, and automatically create orders in Medusa based on uploaded documents.</>}
+    description={<>The <a href="https://medusajs.com/">Medusa</a> integration for Enthusiast allows AI Agents to access your product catalog and perform actions within Medusa. For example, it allows the <a href="/agents/order-intake">Order Intake Agent</a> to find matching products in the catalog, and automatically create orders in Medusa based on uploaded documents.</>}
     integrationKey="medusa"
     pipName="enthusiast-source-medusa"
     registerECommerceIntegrationModule="enthusiast_source_medusa.MedusaIntegration"


### PR DESCRIPTION
 Found a broken internal link in the Medusa integration page that referenced /agents/purchase-order-ocr — an old URL that no longer exists. The correct route is /agents/order-intake.

  Changes:
  - docs/content/integrations/medusa.mdx: updated href from /agents/purchase-order-ocr to /agents/order-intake