### PR TITLE
chore: bump enthusiast-common to 1.7.0

### DIFF
--- a/plugins/enthusiast-common/pyproject.toml
+++ b/plugins/enthusiast-common/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "enthusiast-common"
-version = "1.6.1"
+version = "1.7.0"
 description = "Core interfaces for developing custom Enthusiast plugins and integrations."
 authors = ["Rafal Cymerys <rafal@upsidelab.io>"]
 readme = "README.md"


### PR DESCRIPTION
Part of the 1.7 release — bumps `enthusiast-common` from 1.6.1 to 1.7.0.

Since everything else depends on this, it needs to land first.

**What changed since 1.6.1:**
- new `memory/` module with `BaseMemoryCompactor` interface (part of the memory compactor feature)
- `injectors/base` updated to expose memory compactor
- `config/base` tweaks for Anthropic streaming support
- embedding registry extended to support per-model vector size constraints
- `agents/base` cleaned up after shared tools were extracted to their own plugin

Merge this before the models/agents PRs.