### PR TITLE
chore: bump model plugins, source-medusa + first publish for agent-tools and model-anthropic

### DIFF
--- a/plugins/enthusiast-agent-tools/pyproject.toml
+++ b/plugins/enthusiast-agent-tools/pyproject.toml
@@ -8,7 +8,7 @@ authors = [
 readme = "README.md"
 requires-python = ">=3.10,<4"
 dependencies = [
-    "enthusiast-common (>=1.6.0,<2.0.0)",
+    "enthusiast-common (>=1.7.0,<2.0.0)",
     "langchain (>=1.2.0,<2.0.0)",
 ]
 

--- a/plugins/enthusiast-agent-tools/pyproject.toml
+++ b/plugins/enthusiast-agent-tools/pyproject.toml
@@ -14,7 +14,6 @@ dependencies = [
 
 [project.urls]
 Homepage = "https://upsidelab.io/tools/enthusiast"
-Documentation = "https://upsidelab.io/tools/enthusiast/agents/tools"
 Repository = "https://github.com/upsidelab/enthusiast.git"
 Issues = "https://github.com/upsidelab/enthusiast/issues"
 

--- a/plugins/enthusiast-agent-tools/pyproject.toml
+++ b/plugins/enthusiast-agent-tools/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
 
 [project.urls]
 Homepage = "https://upsidelab.io/tools/enthusiast"
+Documentation = "https://upsidelab.io/tools/enthusiast/agents/tools"
 Repository = "https://github.com/upsidelab/enthusiast.git"
 Issues = "https://github.com/upsidelab/enthusiast/issues"
 

--- a/plugins/enthusiast-model-anthropic/pyproject.toml
+++ b/plugins/enthusiast-model-anthropic/pyproject.toml
@@ -13,12 +13,6 @@ anthropic = ">=0.80,<1.0"
 langchain-anthropic = "^1.4"
 
 
-[project.urls]
-Homepage = "https://upsidelab.io/tools/enthusiast"
-Documentation = "https://upsidelab.io/tools/enthusiast/models/anthropic"
-Repository = "https://github.com/upsidelab/enthusiast.git"
-Issues = "https://github.com/upsidelab/enthusiast/issues"
-
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"

--- a/plugins/enthusiast-model-anthropic/pyproject.toml
+++ b/plugins/enthusiast-model-anthropic/pyproject.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 [tool.poetry.dependencies]
 langchain-core = "^1.2"
 python = "^3.10"
-enthusiast-common = ">=1.6.0,<2"
+enthusiast-common = ">=1.7.0,<2"
 anthropic = ">=0.80,<1.0"
 langchain-anthropic = "^1.4"
 

--- a/plugins/enthusiast-model-anthropic/pyproject.toml
+++ b/plugins/enthusiast-model-anthropic/pyproject.toml
@@ -13,6 +13,12 @@ anthropic = ">=0.80,<1.0"
 langchain-anthropic = "^1.4"
 
 
+[project.urls]
+Homepage = "https://upsidelab.io/tools/enthusiast"
+Documentation = "https://upsidelab.io/tools/enthusiast/models/anthropic"
+Repository = "https://github.com/upsidelab/enthusiast.git"
+Issues = "https://github.com/upsidelab/enthusiast/issues"
+
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"

--- a/plugins/enthusiast-model-azureopenai/pyproject.toml
+++ b/plugins/enthusiast-model-azureopenai/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "enthusiast-model-azureopenai"
-version = "1.3.0"
+version = "1.4.0"
 description = "A plugin for Enthusiast that provides an OpenAI connector."
 authors = ["Damian Sowiński <damian.sowinski@upsidelab.io>"]
 readme = "README.md"

--- a/plugins/enthusiast-model-azureopenai/pyproject.toml
+++ b/plugins/enthusiast-model-azureopenai/pyproject.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 [tool.poetry.dependencies]
 langchain-core = "^1.2"
 python = "^3.10"
-enthusiast-common = ">=1.6.0,<2"
+enthusiast-common = ">=1.7.0,<2"
 openai = "^1.86.0"
 langchain-openai = "^1.1"
 

--- a/plugins/enthusiast-model-google/pyproject.toml
+++ b/plugins/enthusiast-model-google/pyproject.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 [tool.poetry.dependencies]
 langchain-core = "^1.2"
 python = "^3.10"
-enthusiast-common = ">=1.6.0,<2"
+enthusiast-common = ">=1.7.0,<2"
 google-genai = "^1.70.0"
 langchain-google-genai = "^4.2"
 

--- a/plugins/enthusiast-model-google/pyproject.toml
+++ b/plugins/enthusiast-model-google/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "enthusiast-model-google"
-version = "1.3.0"
+version = "1.4.0"
 description = "A plugin for Enthusiast that provides a Google Gemini connector."
 authors = ["Damian Sowiński <damian.sowinski@upsidelab.io>"]
 readme = "README.md"

--- a/plugins/enthusiast-model-mistral/pyproject.toml
+++ b/plugins/enthusiast-model-mistral/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "enthusiast-model-mistral"
-version = "1.2.0"
+version = "1.3.0"
 description = "A plugin for Enthusiast that provides an Mistral connector."
 authors = ["Damian Sowiński <damian.sowinski@upsidelab.io>"]
 readme = "README.md"

--- a/plugins/enthusiast-model-mistral/pyproject.toml
+++ b/plugins/enthusiast-model-mistral/pyproject.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 [tool.poetry.dependencies]
 langchain-core = "^1.2"
 python = "^3.10"
-enthusiast-common = ">=1.6.0,<2"
+enthusiast-common = ">=1.7.0,<2"
 langchain-mistralai = "^1.1"
 mistralai = "^1.9.10"
 

--- a/plugins/enthusiast-model-ollama/pyproject.toml
+++ b/plugins/enthusiast-model-ollama/pyproject.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 [tool.poetry.dependencies]
 langchain-core = "^1.2"
 python = "^3.10"
-enthusiast-common = ">=1.6.0,<2"
+enthusiast-common = ">=1.7.0,<2"
 langchain-ollama = "^1.0"
 
 

--- a/plugins/enthusiast-model-ollama/pyproject.toml
+++ b/plugins/enthusiast-model-ollama/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "enthusiast-model-ollama"
-version = "1.3.0"
+version = "1.4.0"
 description = "A plugin for Enthusiast that provides an Ollama connector."
 authors = ["Rafal Cymerys <rafal@upsidelab.io>"]
 readme = "README.md"

--- a/plugins/enthusiast-model-openai/pyproject.toml
+++ b/plugins/enthusiast-model-openai/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "enthusiast-model-openai"
-version = "1.4.0"
+version = "1.5.0"
 description = "A plugin for Enthusiast that provides an OpenAI connector."
 authors = ["Rafal Cymerys <rafal@upsidelab.io>"]
 readme = "README.md"

--- a/plugins/enthusiast-model-openai/pyproject.toml
+++ b/plugins/enthusiast-model-openai/pyproject.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 [tool.poetry.dependencies]
 langchain-core = "^1.2"
 python = "^3.10"
-enthusiast-common = ">=1.6.0,<2"
+enthusiast-common = ">=1.7.0,<2"
 openai = "^1.86.0"
 langchain-openai = "^1.1"
 

--- a/plugins/enthusiast-source-medusa/pyproject.toml
+++ b/plugins/enthusiast-source-medusa/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "enthusiast-source-medusa"
-version = "1.3.1"
+version = "1.4.0"
 description = "A plugin for Enthusiast that provides a Medusa products importer."
 authors = ["Kuba Szczęśniak <kuba.szczęśniak@upsidelab.io>"]
 readme = "README.md"

--- a/plugins/enthusiast-source-medusa/pyproject.toml
+++ b/plugins/enthusiast-source-medusa/pyproject.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 python = "^3.10"
-enthusiast-common = ">=1.6.1,<2"
+enthusiast-common = ">=1.7.0,<2"
 requests = "^2.32.3"
 
 [build-system]


### PR DESCRIPTION
Part of the 1.7 release — version bumps for all model plugins and source-medusa. Also includes **two packages being published to PyPI for the first time**.

**First-time publishes:**
- `enthusiast-agent-tools` 1.0.0 — shared tools extracted from individual agent plugins (product search, file list, upsert, etc.)
- `enthusiast-model-anthropic` 1.0.0 — new Anthropic/Claude LLM provider

**Version bumps:**
- `enthusiast-model-azureopenai` 1.3.0 → 1.4.0
- `enthusiast-model-google` 1.3.0 → 1.4.0 
- `enthusiast-model-mistral` 1.2.0 → 1.3.0
- `enthusiast-model-ollama` 1.3.0 → 1.4.0 
- `enthusiast-model-openai` 1.4.0 → 1.5.0 
- `enthusiast-source-medusa` 1.3.1 → 1.4.0

Merge after the common PR.