### PR TITLE
chore: bump enthusiast-agent-tool-calling to 1.2.0

### DIFF
--- a/plugins/enthusiast-agent-tool-calling/pyproject.toml
+++ b/plugins/enthusiast-agent-tool-calling/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "enthusiast-agent-tool-calling"
-version = "1.1.0"
+version = "1.2.0"
 description = "Base implementation of a Tool Calling agent for Enthusiast"
 authors = [
     {name = "Damian Sowiński",email = "damian.sowinski@upsidelab.io"}

--- a/plugins/enthusiast-agent-tool-calling/pyproject.toml
+++ b/plugins/enthusiast-agent-tool-calling/pyproject.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 requires-python = ">=3.10,<4"
 dependencies = [
     "enthusiast-agent-tools (>=1.0.0,<2.0.0)",
-    "enthusiast-common (>=1.6.0,<2.0.0)",
+    "enthusiast-common (>=1.7.0,<2.0.0)",
     "langchain (>=1.2.0,<2.0.0)",
 ]
 


### PR DESCRIPTION
Part of the 1.7 release — bumps `enthusiast-agent-tool-calling` from 1.1.0 to 1.2.0.

**What changed since 1.1.0:**
- new `context_window_builder.py` — handles context window management as part of the memory compactor feature
- refactored base agent to work with the new shared `enthusiast-agent-tools` plugin (tools no longer bundled directly)
- minor adjustments for Anthropic provider compatibility

Merge after the common and models PRs.