### PR TITLE
chore: bump agent plugins to 1.4.0

### DIFF
--- a/plugins/enthusiast-agent-catalog-enrichment/pyproject.toml
+++ b/plugins/enthusiast-agent-catalog-enrichment/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "enthusiast-agent-catalog-enrichment"
-version = "1.3.0"
+version = "1.4.0"
 description = "Catalog Enrichment Agent for Enthusiast"
 authors = [
     {name = "Damian Sowiński",email = "damian.sowinski@upsidelab.io"}

--- a/plugins/enthusiast-agent-catalog-enrichment/pyproject.toml
+++ b/plugins/enthusiast-agent-catalog-enrichment/pyproject.toml
@@ -8,9 +8,9 @@ authors = [
 readme = "README.md"
 requires-python = ">=3.10,<4"
 dependencies = [
-    "enthusiast-common (>=1.6.0,<2.0.0)",
+    "enthusiast-common (>=1.7.0,<2.0.0)",
     "langchain (>=1.2.0,<2.0.0)",
-    "enthusiast-agent-tool-calling (>=1.1.0)",
+    "enthusiast-agent-tool-calling (>=1.2.0)",
     "enthusiast-agent-tools (>=1.0.0,<2.0.0)",
 ]
 

--- a/plugins/enthusiast-agent-catalog-web-import/pyproject.toml
+++ b/plugins/enthusiast-agent-catalog-web-import/pyproject.toml
@@ -10,7 +10,7 @@ requires-python = ">=3.10,<4"
 dependencies = [
     "enthusiast-common (>=1.7.0,<2.0.0)",
     "langchain (>=1.2.0,<2.0.0)",
-    "enthusiast-agent-tool-calling (>=1.1.0)",
+    "enthusiast-agent-tool-calling (>=1.2.0)",
     "enthusiast-agent-tools (>=1.0.0,<2.0.0)",
     "beautifulsoup4 (>=4.14.2,<5.0.0)",
     "curl_cffi (>=0.7.0,<1.0.0)",

--- a/plugins/enthusiast-agent-invoice-scanning/pyproject.toml
+++ b/plugins/enthusiast-agent-invoice-scanning/pyproject.toml
@@ -8,9 +8,9 @@ authors = [
 readme = "README.md"
 requires-python = ">=3.10,<4"
 dependencies = [
-    "enthusiast-common (>=1.6.2,<2.0.0)",
+    "enthusiast-common (>=1.7.0,<2.0.0)",
     "langchain (>=1.2.0,<2.0.0)",
-    "enthusiast-agent-tool-calling (>=1.1.0)",
+    "enthusiast-agent-tool-calling (>=1.2.0)",
     "enthusiast-agent-tools (>=1.0.0,<2.0.0)",
 ]
 

--- a/plugins/enthusiast-agent-order-intake/pyproject.toml
+++ b/plugins/enthusiast-agent-order-intake/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "enthusiast-agent-order-intake"
-version = "1.3.0"
+version = "1.4.0"
 description = "Order Intake Agent for Enthusiast"
 authors = [
     {name = "Damian Sowiński",email = "damian.sowinski@upsidelab.io"}

--- a/plugins/enthusiast-agent-order-intake/pyproject.toml
+++ b/plugins/enthusiast-agent-order-intake/pyproject.toml
@@ -8,9 +8,9 @@ authors = [
 readme = "README.md"
 requires-python = ">=3.10,<4"
 dependencies = [
-    "enthusiast-common (>=1.6.0,<2.0.0)",
+    "enthusiast-common (>=1.7.0,<2.0.0)",
     "langchain (>=1.2.0,<2.0.0)",
-    "enthusiast-agent-tool-calling (>=1.1.0)",
+    "enthusiast-agent-tool-calling (>=1.2.0)",
     "enthusiast-agent-tools (>=1.0.0,<2.0.0)",
 ]
 

--- a/plugins/enthusiast-agent-product-search/pyproject.toml
+++ b/plugins/enthusiast-agent-product-search/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "enthusiast-agent-product-search"
-version = "1.3.0"
+version = "1.4.0"
 description = "Product Search Agent for Enthusiast"
 authors = [
     {name = "Damian Sowiński",email = "damian.sowinski@upsidelab.io"}

--- a/plugins/enthusiast-agent-product-search/pyproject.toml
+++ b/plugins/enthusiast-agent-product-search/pyproject.toml
@@ -8,9 +8,9 @@ authors = [
 readme = "README.md"
 requires-python = ">=3.10,<4"
 dependencies = [
-    "enthusiast-common (>=1.6.0,<2.0.0)",
+    "enthusiast-common (>=1.7.0,<2.0.0)",
     "langchain (>=1.2.0,<2.0.0)",
-    "enthusiast-agent-tool-calling (>=1.1.0)",
+    "enthusiast-agent-tool-calling (>=1.2.0)",
     "enthusiast-agent-tools (>=1.0.0,<2.0.0)",
 ]
 

--- a/plugins/enthusiast-agent-user-manual-search/pyproject.toml
+++ b/plugins/enthusiast-agent-user-manual-search/pyproject.toml
@@ -8,9 +8,9 @@ authors = [
 readme = "README.md"
 requires-python = ">=3.10,<4"
 dependencies = [
-    "enthusiast-common (>=1.6.0,<2.0.0)",
+    "enthusiast-common (>=1.7.0,<2.0.0)",
     "langchain (>=1.2.0,<2.0.0)",
-    "enthusiast-agent-tool-calling (>=1.1.0)",
+    "enthusiast-agent-tool-calling (>=1.2.0)",
 ]
 
 [project.urls]

--- a/plugins/enthusiast-agent-user-manual-search/pyproject.toml
+++ b/plugins/enthusiast-agent-user-manual-search/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "enthusiast-agent-user-manual-search"
-version = "1.3.0"
+version = "1.4.0"
 description = "User Manual Search Agent for Enthusiast"
 authors = [
     {name = "Damian Sowiński",email = "damian.sowinski@upsidelab.io"}


### PR DESCRIPTION
Part of the 1.7 release — version bumps for agent plugins. Also includes **two packages being published for the first time**.

> Before merging, make sure `enthusiast-agent-catalog-web-import` and `enthusiast-agent-invoice-scanning` are published to PyPI — they're new packages that have never been released before.


**Version bumps:**
- `enthusiast-agent-catalog-enrichment` 1.3.0 → 1.4.0 
- `enthusiast-agent-product-search` 1.3.0 → 1.4.0 
- `enthusiast-agent-user-manual-search` 1.3.0 → 1.4.0 
- `enthusiast-agent-order-intake` 1.3.0 → 1.4.0 

Merge after tool-calling is published, before the server PR.