### PR TITLE
fix: consistent response schema for the agentic execution creation endpoint

### DIFF
--- a/server/agent/agentic_execution/tests/test_views.py
+++ b/server/agent/agentic_execution/tests/test_views.py
@@ -317,10 +317,13 @@ class TestStartAgenticExecutionView:
 
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
-    def test_happy_path_returns_202_with_execution_data(self, api_client, url):
+    def test_happy_path_returns_202_with_execution_data(self, api_client, url, user, agent, dataset):
         with patch("agent.agentic_execution.views.AgenticExecutionService.start") as mock_start, \
              patch("agent.agentic_execution.services.run_agentic_execution_task.delay"):
-            mock_start.return_value = baker.make(AgenticExecution)
+            conversation = baker.make(Conversation, user=user, agent=agent, data_set=dataset)
+            baker.make("agent.ConversationFile", conversation=conversation, is_hidden=False)
+            execution = baker.make(AgenticExecution, agent=agent, conversation=conversation, input={"required_field": "hello"})
+            mock_start.return_value = execution
             response = api_client.post(
                 url, {"execution_key": "dummy", "input": {"required_field": "hello"}}, format="json"
             )

--- a/server/agent/agentic_execution/tests/test_views.py
+++ b/server/agent/agentic_execution/tests/test_views.py
@@ -320,9 +320,7 @@ class TestStartAgenticExecutionView:
     def test_happy_path_returns_202_with_execution_data(self, api_client, url):
         with patch("agent.agentic_execution.views.AgenticExecutionService.start") as mock_start, \
              patch("agent.agentic_execution.services.run_agentic_execution_task.delay"):
-            mock_execution = baker.prepare(AgenticExecution)
-            mock_execution.pk = 1
-            mock_start.return_value = mock_execution
+            mock_start.return_value = baker.make(AgenticExecution)
             response = api_client.post(
                 url, {"execution_key": "dummy", "input": {"required_field": "hello"}}, format="json"
             )

--- a/server/agent/agentic_execution/views.py
+++ b/server/agent/agentic_execution/views.py
@@ -109,7 +109,7 @@ class StartAgenticExecutionView(APIView):
         except UnsupportedFileTypeError as exc:
             return Response({"detail": str(exc)}, status=status.HTTP_400_BAD_REQUEST)
 
-        return Response(AgenticExecutionSerializer(execution).data, status=status.HTTP_202_ACCEPTED)
+        return Response(AgenticExecutionDetailSerializer(execution).data, status=status.HTTP_202_ACCEPTED)
 
 
 class AgenticExecutionListView(ListAPIView):


### PR DESCRIPTION
minor fix (I noticed that endpoints: `POST: /api/agents/<agent_id>/agentic-executions/` and `GET /api/agentic-executions/<execution_id>` yielded inconsistent response - I updated the former to use the same serializer as the latter)