### PR TITLE
chore: bump remaining source plugins to 1.4.0

### DIFF
--- a/plugins/enthusiast-source-sample/pyproject.toml
+++ b/plugins/enthusiast-source-sample/pyproject.toml
@@ -1,13 +1,13 @@
 [tool.poetry]
 name = "enthusiast-source-sample"
-version = "1.3.0"
+version = "1.4.0"
 description = "A plugin for Enthusiast that provides a sample data source for demo purposes."
 authors = ["Rafal Cymerys <rafal@upsidelab.io>"]
 readme = "README.md"
 
 [tool.poetry.dependencies]
 python = "^3.10"
-enthusiast-common = ">=1.6.0,<2"
+enthusiast-common = ">=1.7.0,<2"
 
 
 [build-system]

--- a/plugins/enthusiast-source-sanitycms/pyproject.toml
+++ b/plugins/enthusiast-source-sanitycms/pyproject.toml
@@ -1,13 +1,13 @@
 [tool.poetry]
 name = "enthusiast-source-sanitycms"
-version = "1.3.0"
+version = "1.4.0"
 description = "A plugin for Enthusiast that provides a SanityCMS documents importer."
 authors = ["Kuba Szczęśniak <kuba.szczesniak@upsidelab.io>"]
 readme = "README.md"
 
 [tool.poetry.dependencies]
 python = "^3.10"
-enthusiast-common = ">=1.6.0,<2"
+enthusiast-common = ">=1.7.0,<2"
 requests = "^2.32.3"
 
 

--- a/plugins/enthusiast-source-shopify/pyproject.toml
+++ b/plugins/enthusiast-source-shopify/pyproject.toml
@@ -1,13 +1,13 @@
 [tool.poetry]
 name = "enthusiast-source-shopify"
-version = "1.3.0"
+version = "1.4.0"
 description = "A plugin for Enthusiast that provides a Shopify products importer."
 authors = ["Rafal Cymerys <rafal@upsidelab.io>"]
 readme = "README.md"
 
 [tool.poetry.dependencies]
 python = "^3.10"
-enthusiast-common = ">=1.6.0,<2"
+enthusiast-common = ">=1.7.0,<2"
 shopifyapi = "^12.7.0"
 
 

--- a/plugins/enthusiast-source-shopware/pyproject.toml
+++ b/plugins/enthusiast-source-shopware/pyproject.toml
@@ -1,13 +1,13 @@
 [tool.poetry]
 name = "enthusiast-source-shopware"
-version = "1.3.0"
+version = "1.4.0"
 description = "A plugin for Enthusiast that provides a Shopware products importer."
 authors = ["Mateusz Porebski <mateusz.porebski@upsidelab.io>"]
 readme = "README.md"
 
 [tool.poetry.dependencies]
 python = "^3.10"
-enthusiast-common = ">=1.6.0,<2"
+enthusiast-common = ">=1.7.0,<2"
 
 
 [build-system]

--- a/plugins/enthusiast-source-solidus/pyproject.toml
+++ b/plugins/enthusiast-source-solidus/pyproject.toml
@@ -1,13 +1,13 @@
 [tool.poetry]
 name = "enthusiast-source-solidus"
-version = "1.3.0"
+version = "1.4.0"
 description = "A plugin for Enthusiast that provides a Solidus products importer."
 authors = ["Rafal Cymerys <rafal@upsidelab.io>"]
 readme = "README.md"
 
 [tool.poetry.dependencies]
 python = "^3.10"
-enthusiast-common = ">=1.6.0,<2"
+enthusiast-common = ">=1.7.0,<2"
 requests = "^2.32.3"
 
 

--- a/plugins/enthusiast-source-woocommerce/pyproject.toml
+++ b/plugins/enthusiast-source-woocommerce/pyproject.toml
@@ -1,13 +1,13 @@
 [tool.poetry]
 name = "enthusiast-source-woocommerce"
-version = "1.3.0"
+version = "1.4.0"
 description = "A plugin for Enthusiast that provides a WooCommerce products importer."
 authors = ["jakubl2290", "Rafal Cymerys <rafal@upsidelab.io>"]
 readme = "README.md"
 
 [tool.poetry.dependencies]
 python = "^3.10"
-enthusiast-common = ">=1.6.0,<2"
+enthusiast-common = ">=1.7.0,<2"
 woocommerce = "^3.0.0"
 
 

--- a/plugins/enthusiast-source-wordpress/pyproject.toml
+++ b/plugins/enthusiast-source-wordpress/pyproject.toml
@@ -1,13 +1,13 @@
 [tool.poetry]
 name = "enthusiast-source-wordpress"
-version = "1.3.0"
+version = "1.4.0"
 description = "A plugin for Enthusiast that provides a Wordpress documents importer."
 authors = ["Rafal Cymerys <rafal@upsidelab.io>"]
 readme = "README.md"
 
 [tool.poetry.dependencies]
 python = "^3.10"
-enthusiast-common = ">=1.6.0,<2"
+enthusiast-common = ">=1.7.0,<2"
 requests = "^2.32.3"
 
 


### PR DESCRIPTION
Part of the 1.7 release — bumps the remaining source plugins that weren't covered in the models PR.

All plugins get version 1.3.0 → 1.4.0 and the enthusiast-common minimum constraint updated to >=1.7.0.

- `enthusiast-source-sample` 1.3.0 → 1.4.0
- `enthusiast-source-sanitycms` 1.3.0 → 1.4.0
- `enthusiast-source-shopify` 1.3.0 → 1.4.0
- `enthusiast-source-shopware` 1.3.0 → 1.4.0
- `enthusiast-source-solidus` 1.3.0 → 1.4.0
- `enthusiast-source-woocommerce` 1.3.0 → 1.4.0
- `enthusiast-source-wordpress` 1.3.0 → 1.4.0

Can be merged alongside the models PR — no dependency between them.